### PR TITLE
Fix attaching hotkeys to the window in TS definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ interface HotKeysProps extends FocusTrapProps<HotKeys> {
   /**
    * The object that the internal key listeners should be bound to
    */
-  attach?: React.Component | Element ;
+  attach?: React.Component | Element | Window;
 }
 
 /**


### PR DESCRIPTION
I was trying to attach the hotkeys to the `window`, as suggested here: https://github.com/greena13/react-hotkeys/issues/12#issuecomment-128278693. Unfortunately, that does not work at the moment when compiling using Typescript, as the `attach` property only accepts elements or components.

```
[...]
Types of property 'attach' are incompatible.
Type 'Window' is not assignable to type 'Element | Component<{}, {}> | undefined'.
```

Luckily it's a simple fix, by adding `Window` as an accepted type for the `attach` property.