### PR TITLE
Fix typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import FocusTrap from './lib/FocusTrap';
 
 type MouseTrapKeySequence = string | Array<string>;
 
@@ -17,7 +18,7 @@ interface FocusTrapProps extends React.HTMLProps<FocusTrap> {
   component?: React.Component | string;
 }
 
-interface HotKeysProps extends FocusTrapProps<HotKeys> {
+interface HotKeysProps extends React.Props<HotKeys>, FocusTrapProps {
   /**
    * A mapping of action names to key combinations
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ interface FocusTrapProps extends React.HTMLProps<FocusTrap> {
   component?: React.Component | string;
 }
 
-interface HotKeysProps extends React.Props<HotKeys>, FocusTrapProps {
+interface HotKeysProps extends React.HTMLAttributes<HotKeys>, FocusTrapProps {
   /**
    * A mapping of action names to key combinations
    */
@@ -39,6 +39,16 @@ interface HotKeysProps extends React.Props<HotKeys>, FocusTrapProps {
    * The object that the internal key listeners should be bound to
    */
   attach?: React.Component | Element | Window;
+
+  /**
+   * Function to call when this component gains focus in the browser
+   */
+  onFocus?: () => void;
+
+  /**
+   * Function to call when this component loses focus in the browser
+   */
+  onBlur?: () => void;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ type KeyEventName = 'keyup' | 'keydown' | 'keypress';
 
 interface KeyMapOptions {
   sequence: MouseTrapKeySequence;
-  action: KeyEventName = 'keypress';
+  action: KeyEventName;
 }
 
 interface FocusTrapProps extends React.HTMLProps<FocusTrap> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,16 +38,6 @@ interface HotKeysProps extends FocusTrapProps<HotKeys> {
    * The object that the internal key listeners should be bound to
    */
   attach?: React.Component | Element | Window;
-
-  /**
-   * Function to call when this component gains focus in the browser
-   */
-  onFocus?: () => void;
-
-  /**
-   * Function to call when this component loses focus in the browser
-   */
-  onBlur?: () => void;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,9 +40,14 @@ interface HotKeysProps extends FocusTrapProps<HotKeys> {
   attach?: React.Component | Element | Window;
 
   /**
-   * TODO: Try and remove for inherited value from React.HTMLProps
+   * Function to call when this component gains focus in the browser
    */
-  className?: string;
+  onFocus?: () => void;
+
+  /**
+   * Function to call when this component loses focus in the browser
+   */
+  onBlur?: () => void;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ interface HotKeysProps extends FocusTrapProps<HotKeys> {
   /**
    * A mapping of action names to handler functions
    */
-  handlers?: { [key: string]: (keyEvent: KeyboardEvent) => void };
+  handlers?: { [key: string]: (keyEvent?: KeyboardEvent) => void };
 
   /**
    * Whether the component should behave as if it current has browser focus

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ interface HotKeysProps extends FocusTrapProps<HotKeys> {
    * Whether the component should behave as if it current has browser focus
    * event when it doesn't
    */
-  focused?: boolean = false;
+  focused?: boolean;
 
   /**
    * The object that the internal key listeners should be bound to

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ interface KeyMapOptions {
   action: KeyEventName;
 }
 
-interface FocusTrapProps extends React.HTMLProps<FocusTrap> {
+interface FocusTrapProps {
   /**
    * The React component that should be used in the DOM to wrap the FocusTrap's
    * children and have the internal key listeners bound to


### PR DESCRIPTION
This pull request aims to resolve #84 

I have tested this by developing and `npm pack`ing locally, then installing the package into my [FreeMAN](https://github.com/matthew-matvei/freeman) app which uses `react-hotkeys` fairly extensively.

- Importing `FocusTrap` (resolved `ts` errors, though actual type definitions instead of 'importing' js file for this class might be best moving forward)
- Removed initialisers in `interface` definitions
- Made handler function `keyEvent` optional, since the API doesn't seem to require it
- `HotKeysProps` extends React's `Props<HotKeys>` in order to get in-built props like `ref` and `children`

I don't think this project is set up for any automated type tests or `tslint`ing, so I would suggest anyone interested to build this branch locally, `npm pack` and install it into where you are consuming it. I'm aware my own `tsconfig.json` could potentially make this solution not work for you.