### PR TITLE
fix proptype declaration

### DIFF
--- a/lib/FocusTrap.js
+++ b/lib/FocusTrap.js
@@ -21,7 +21,7 @@ class FocusTrap extends Component {
      * Component (or component type as a string) to use as a wrapper or
      * parent of this component's children
      */
-    component: PropTypes.oneOfType([ PropTypes.node, PropTypes.string ]),
+    component: PropTypes.oneOfType([ PropTypes.func, PropTypes.string ]),
 
     /**
      * Children to place in the wrapper or parent


### PR DESCRIPTION
If you try to pass a custom component you get the following warning

`Failed prop type: Invalid prop 'component' supplied to 'FocusTrap'.`

[Sandbox](https://codesandbox.io/s/qz7j6537vq)