### PR TITLE
Refactored withHotKeys.js to avoid calling `.bind(this)` all the time.

### DIFF
--- a/lib/withHotKeys.js
+++ b/lib/withHotKeys.js
@@ -49,7 +49,7 @@ const withHotKeys = (keyMap) => ((Component) =>
         this._setRef = this._setRef.bind(this);
         this.state = {
           handlers: {}
-        }
+        };
       }
       
       componentDidMount() {

--- a/lib/withHotKeys.js
+++ b/lib/withHotKeys.js
@@ -62,6 +62,7 @@ const withHotKeys = (keyMap) => ((Component) =>
 
       render() {
         const { handlers } = this.state;
+        document.createDocumentFragment();
         // Setting component as documentfragment to avoid unexpected stylistic changes to the wrapped component
         return (
             <HotKeys component="document-fragment" keyMap={keyMap} handlers={handlers}>

--- a/lib/withHotKeys.js
+++ b/lib/withHotKeys.js
@@ -44,10 +44,14 @@ import HotKeys from './HotKeys';
  */
 const withHotKeys = (keyMap) => ((Component) =>
     class HotKeysWrapper extends PureComponent {
-      state = {
-        handlers: {}
-      };
-
+      constructor(props) {
+        super(props);
+        this._setRef = this._setRef.bind(this);
+        this.state = {
+          handlers: {}
+        }
+      }
+      
       componentDidMount() {
         this.setState({handlers: this._ref.hotKeyHandlers});
       }
@@ -57,14 +61,12 @@ const withHotKeys = (keyMap) => ((Component) =>
       }
 
       render() {
-        const {handlers} = this.state;
-        const DocumentFragment = document.createDocumentFragment();
-
+        const { handlers } = this.state;
         // Setting component as documentfragment to avoid unexpected stylistic changes to the wrapped component
         return (
             <HotKeys component="document-fragment" keyMap={keyMap} handlers={handlers}>
                 <Component
-                    ref={this._setRef.bind(this)}
+                    ref={this._setRef}
                     {...this.props}
                 />
             </HotKeys>


### PR DESCRIPTION
Refactored withHotKeys.js to avoid calling `.bind(this)` every time when a hot key is pressed.