### PR TITLE
Fixed bug blocking parent handler after removing sequence from child

### DIFF
--- a/lib/HotKeys.js
+++ b/lib/HotKeys.js
@@ -245,6 +245,9 @@ class HotKeys extends Component {
     const keyMapHasChanged = this.updateMap();
 
     if (force || keyMapHasChanged || hasChanged(handlers, prevHandlers)) {
+      if (this.context.hotKeyParent) {
+        this.context.hotKeyParent.childHandledSequence(null);
+      }
       this.syncHandlersToMousetrap();
     }
   }


### PR DESCRIPTION
Hey,
we encountered the following problem:

1a) We had a parent HotKeys component that handled `enter`.
1b) We had a child HotKeys component that handled `enter` aswell.
2) After the childs handler was called (after pressing enter) we removed the child's handler for `enter`.
3) The parents handler was still blocked by `__lastChildSequence__ ` although the child doesn't have a handler for that anymore

With the proposed change, this case works for us.

Best
Ansgar