### PR TITLE
Add support for additional props to HOC

### DIFF
--- a/lib/withHotKeys.js
+++ b/lib/withHotKeys.js
@@ -40,9 +40,11 @@ import HotKeys from './HotKeys';
  * @returns {function} Returns the HOC-wrapped component.
  *
  * @param {Object} keyMap an action-to-keyboard-key mapping
+ * @param {boolean} focused Whether HotKeys should behave as if it has focus in the browser
+ * @param {Object} attach The DOM element the keyboard listeners should be attached to
  * @summary An HOC that provides the wrappedComponent with the ability to implement keyboard actions
  */
-const withHotKeys = (keyMap) => ((Component) =>
+const withHotKeys = (keyMap, focused, attach) => ((Component) =>
     class HotKeysWrapper extends PureComponent {
       constructor(props) {
         super(props);
@@ -63,9 +65,17 @@ const withHotKeys = (keyMap) => ((Component) =>
       render() {
         const { handlers } = this.state;
         
+        const props = {
+          keyMap,
+          handlers,
+          component: "document-fragment",
+          focused,
+          attach
+        };
+
         // Setting component as documentfragment to avoid unexpected stylistic changes to the wrapped component
         return (
-            <HotKeys component="document-fragment" keyMap={keyMap} handlers={handlers}>
+            <HotKeys {...props}>
                 <Component
                     ref={this._setRef}
                     {...this.props}

--- a/lib/withHotKeys.js
+++ b/lib/withHotKeys.js
@@ -40,11 +40,10 @@ import HotKeys from './HotKeys';
  * @returns {function} Returns the HOC-wrapped component.
  *
  * @param {Object} keyMap an action-to-keyboard-key mapping
- * @param {boolean} focused Whether HotKeys should behave as if it has focus in the browser
- * @param {Object} attach The DOM element the keyboard listeners should be attached to
+ * @param {Object} options parameters tp pass in as props to the HotKeys componenet
  * @summary An HOC that provides the wrappedComponent with the ability to implement keyboard actions
  */
-const withHotKeys = (keyMap, focused, attach) => ((Component) =>
+const withHotKeys = (keyMap, options) => ((Component) =>
     class HotKeysWrapper extends PureComponent {
       constructor(props) {
         super(props);
@@ -69,8 +68,7 @@ const withHotKeys = (keyMap, focused, attach) => ((Component) =>
           keyMap,
           handlers,
           component: "document-fragment",
-          focused,
-          attach
+          ...options
         };
 
         // Setting component as documentfragment to avoid unexpected stylistic changes to the wrapped component


### PR DESCRIPTION
Adds support for the `focused` and `attach` props for the `withHotKeys()` HOC, as per the discussion in #96.