### PR TITLE
Fix link to demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A declarative library for handling hotkeys and focus areas in React applications
 
 ## Live Example
 
-Play with a live example of [react-hotkeys](https://codesandbox.io/s/84p9kxv3k2)!
+Play with a live example of [react-hotkeys](https://codesandbox.io/s/x73mw4knlo)!
 
 ## Usage
 


### PR DESCRIPTION
`this.changeColor` resulted in `undefined` because `changeColor` was defined after the `hotKeyHandlers` in `HOCWrappedNode`. https://codesandbox.io/s/x73mw4knlo updates the code so that `changeColor` is defined first and available in the scope of `hotKeyHandlers`. Pressing `ALT+C` on the HOC node now works.