### PR TITLE
Cross-platform build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chai-enzyme": "^1.0.0-beta.0",
     "cheerio": "^1.0.0-0",
     "css-loader": "^0.9.1",
+    "cross-env": "^5.2.0",
     "enzyme": "^3.0.0",
     "enzyme-adapter-react-16": "^1.0.0",
     "eslint": "^4.1.1",
@@ -54,7 +55,6 @@
     "webpack": "^1.7.3"
   },
   "dependencies": {
-    "cross-env": "^5.2.0",
     "lodash.isboolean": "^3.0.3",
     "lodash.isequal": "^4.5.0",
     "lodash.isobject": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "webpack": "^1.7.3"
   },
   "dependencies": {
+    "cross-env": "^5.2.0",
     "lodash.isboolean": "^3.0.3",
     "lodash.isequal": "^4.5.0",
     "lodash.isobject": "^3.0.2",
@@ -83,12 +84,12 @@
     "build-cjs": "rm -rf cjs && npm run build-development && npm run build-production",
     "build-es": "rm -rf es && npm run build-es-development && npm run build-es-production",
     "build-umd": "rm -rf umd && npm run build-umd-development && npm run build-umd-production",
-    "build-development": "BABEL_ENV=development NODE_ENV=development babel lib -d cjs",
-    "build-es-development": "BABEL_ENV=es-development NODE_ENV=development babel lib -d es",
-    "build-umd-development": "BABEL_ENV=umd-development NODE_ENV=development rollup --format umd --name ReactHotkeys -c --file umd/react-hotkeys.js",
-    "build-production": "BABEL_ENV=production NODE_ENV=production rollup --format cjs -c --file cjs/react-hotkeys.production.min.js",
-    "build-es-production": "BABEL_ENV=production NODE_ENV=production rollup --format es -c --file es/react-hotkeys.production.min.js",
-    "build-umd-production": "BABEL_ENV=production NODE_ENV=production rollup --format umd --name ReactHotkeys -c --file umd/react-hotkeys.min.js"
+    "build-development": "cross-env BABEL_ENV=development NODE_ENV=development babel lib -d cjs",
+    "build-es-development": "cross-env BABEL_ENV=es-development NODE_ENV=development babel lib -d es",
+    "build-umd-development": "cross-env BABEL_ENV=umd-development NODE_ENV=development rollup --format umd --name ReactHotkeys -c --file umd/react-hotkeys.js",
+    "build-production": "cross-env BABEL_ENV=production NODE_ENV=production rollup --format cjs -c --file cjs/react-hotkeys.production.min.js",
+    "build-es-production": "cross-env BABEL_ENV=production NODE_ENV=production rollup --format es -c --file es/react-hotkeys.production.min.js",
+    "build-umd-production": "cross-env BABEL_ENV=production NODE_ENV=production rollup --format umd --name ReactHotkeys -c --file umd/react-hotkeys.min.js"
   },
   "author": "Aleck Greenham",
   "contributors": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1426,11 +1426,28 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
+cross-env@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
     lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -2866,7 +2883,7 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
-is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
@@ -3353,6 +3370,10 @@ nearley@^2.7.10:
     railroad-diagrams "^1.0.0"
     randexp "^0.4.2"
 
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+
 nise@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/nise/-/nise-1.2.0.tgz#079d6cadbbcb12ba30e38f1c999f36ad4d6baa53"
@@ -3710,7 +3731,7 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 


### PR DESCRIPTION
## Purpose
When I tried to `npm install` a fresh clone on windows I got errors from the environment variables set by the build commands.
![image](https://user-images.githubusercontent.com/20704067/45892261-36aac600-bd8d-11e8-829a-0bca9528ee35.png)

## Approach
Add an npm module `cross-env` that allows for commands that set environment variables to function cross platform.
