### PR TITLE
Provide an innerRef prop

### DIFF
--- a/lib/FocusTrap.js
+++ b/lib/FocusTrap.js
@@ -26,7 +26,12 @@ class FocusTrap extends Component {
     /**
      * Children to place in the wrapper or parent
      */
-    children: PropTypes.node
+    children: PropTypes.node,
+
+    /**
+     * A ref to add to the underlying DOM wrapper node
+     */
+    innerRef: PropTypes.object
   };
 
   static defaultProps = {
@@ -37,11 +42,12 @@ class FocusTrap extends Component {
     const {
       component: Component,
       children,
+      innerRef,
       ...props
     } = this.props;
 
     return (
-      <Component tabIndex="-1" {...props}>
+      <Component ref={innerRef} tabIndex="-1" {...props}>
         {children}
       </Component>
     );

--- a/lib/HotKeys.js
+++ b/lib/HotKeys.js
@@ -86,6 +86,11 @@ class HotKeys extends Component {
      * Function to call when this component loses focus in the browser
      */
     onBlur: PropTypes.func,
+
+    /**
+     * A ref to add to the underlying DOM wrapper node
+     */
+    innerRef: PropTypes.object
   };
 
   static childContextTypes = {


### PR DESCRIPTION
This allows access to the underlying DOM wrapper node, which is useful if you need to call `focus`. In my use case I have several different `HotKeys` components on different parts of the page, and want to pass focus from one to another. They don't always have children with a tabindex, so there is no other element to add a ref to. Another option could be using `state` and the `focused` property, but in my testing the `focused` property doesn't really seem to work.

The `innerRef` pattern seems to be idiomatic, being used by e.g. [react-router](https://github.com/ReactTraining/react-router) and [formik](https://github.com/jaredpalmer/formik).

Another option would be using [ref forwarding](https://reactjs.org/docs/forwarding-refs.html), but that would be backwards-incompatible for anyone currently using refs to access the `HotKeys` component itself.