### PR TITLE
Improve types for innerRef

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -93,7 +93,7 @@ export interface HotKeysProps extends HotKeysEnabledProps {
    */
   component?: ReactComponent;
 
-  innerRef?: React.RefObject<HTMLInputElement>;
+  innerRef?: React.RefObject<HTMLElement>;
 }
 
 /**


### PR DESCRIPTION
`HTMLInputElement` only supports for input elements, but even in `Readme` there is ref for divs. With current typing, it's not possible. With this addition its possible to set ref to any `HTML` element.