### PR TITLE
Fixed innerRef prop type in HotKeys

### DIFF
--- a/src/HotKeys.js
+++ b/src/HotKeys.js
@@ -25,7 +25,7 @@ HotKeys.propTypes = {
   /**
    * A ref to add to the underlying DOM-mountable node
    */
-  innerRef: PropTypes.object
+  innerRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
 };
 
 export default HotKeys;


### PR DESCRIPTION
Fixed the prop type for innerRef to receive function as value for cases where ref is not instantiated using `React.createRef`.

Current behavior:

<img width="1423" alt="Screenshot 2019-04-10 at 8 41 40 PM" src="https://user-images.githubusercontent.com/189344/55890966-50004c00-5bd1-11e9-82c2-846510fb0b5a.png">
