### PR TITLE
fixed a type definition error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -233,7 +233,7 @@ export interface ConfigurationOptions {
    * Hotkeys. By default, keyboard events originating elements with a tag name in
    * ignoreTags, or a isContentEditable property of true, are ignored.
    */
-  ignoreEventsCondition?: (KeyboardEvent) => boolean,
+  ignoreEventsCondition?: (keyEvent: KeyboardEvent) => boolean,
 
   /**
    * Whether React HotKeys should simulate keypress events for the keys that do not


### PR DESCRIPTION
```
ignoreEventsCondition?: (KeyboardEvent) => boolean,
```
should be
```
ignoreEventsCondition?: (keyEvent: KeyboardEvent) => boolean,
```