### PR TITLE
🐛 Fix #172: Fix resolving the Backspace key

### DIFF
--- a/src/const/KeysWithoutPressEventDictionary.js
+++ b/src/const/KeysWithoutPressEventDictionary.js
@@ -8,7 +8,7 @@ const KeysWithoutPressEventDictionary = {
   Meta: true,
   Enter: true,
   Tab: true,
-  BackSpace: true,
+  Backspace: true,
   ArrowRight: true,
   ArrowLeft: true,
   ArrowUp: true,

--- a/src/const/SpecialKeysDictionary.js
+++ b/src/const/SpecialKeysDictionary.js
@@ -9,7 +9,7 @@ const SpecialKeysDictionary = {
   Enter: true,
   Tab: true,
   CapsLock: true,
-  BackSpace: true,
+  Backspace: true,
   Escape: true,
 };
 

--- a/src/helpers/parsing-key-maps/isValidKey.js
+++ b/src/helpers/parsing-key-maps/isValidKey.js
@@ -4,6 +4,8 @@ function isValidKey(keyName) {
   return isSpecialKey(keyName) || String.fromCharCode(keyName.charCodeAt(0)) === keyName;
 }
 
-export class InvalidKeyNameError extends Error {}
+export class InvalidKeyNameError extends Error {
+  name = 'InvalidKeyNameError'
+}
 
 export default isValidKey;

--- a/test/HotKeys/focus-only/ActionAndHandlerResolution.spec.js
+++ b/test/HotKeys/focus-only/ActionAndHandlerResolution.spec.js
@@ -117,7 +117,5 @@ describe('Action and handler resolution:', function () {
         });
       });
     });
-
   });
-
 });

--- a/test/IgnoreKeys/IgnoringKeyEvents.spec.js
+++ b/test/IgnoreKeys/IgnoringKeyEvents.spec.js
@@ -114,6 +114,49 @@ describe('Ignoring key events using IgnoreKeys:', function () {
     });
   });
 
+  describe('when the except option is used with Backspace', () => {
+    beforeEach(function () {
+      this.keyMap = {
+        'ACTION_A': 'a',
+        'ACTION_B': 'Backspace'
+      };
+
+      this.handlerA = sinon.spy();
+      this.handlerB = sinon.spy();
+
+      this.handlers = {
+        'ACTION_A': this.handlerA,
+        'ACTION_B': this.handlerB,
+      };
+
+      this.wrapper = mount(
+        <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+          <IgnoreKeys except={["Backspace"]}>
+            <div className="childElement" />
+          </IgnoreKeys>
+        </HotKeys>
+      );
+
+      this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+      this.targetElement.focus();
+    });
+
+    it('then ignores all key events except Backspace \
+       (https://github.com/greena13/react-hotkeys/issues/172)', function() {
+      this.targetElement.keyDown(Key.A);
+      this.targetElement.keyPress(Key.A);
+      this.targetElement.keyUp(Key.A);
+
+      expect(this.handlerA).to.not.have.been.called;
+
+      this.targetElement.keyDown('Backspace');
+      this.targetElement.keyPress('Backspace');
+      this.targetElement.keyUp('Backspace');
+
+      expect(this.handlerB).to.have.been.called;
+    });
+  });
+
   describe('when the only and the except option are used', () => {
     beforeEach(function () {
       this.wrapper = mount(


### PR DESCRIPTION
# Context

The `Backspace` key was not being correctly resolved, causing it to raise an error when [used with the IgnoreKeys component](https://github.com/greena13/react-hotkeys/issues/172).

# This pull request

* (Hopefully) fixed the resolution of `Backspace` key events for good.
* Gives that (custom) error a `name` attribute, so it's more evident what the underlying problem was.