### PR TITLE
Fix #166: Fix over-zealous modifier flag discrepancy correction

### DIFF
--- a/src/lib/strategies/AbstractKeyEventStrategy.js
+++ b/src/lib/strategies/AbstractKeyEventStrategy.js
@@ -1112,7 +1112,8 @@ class AbstractKeyEventStrategy {
    * on new key events
    * @param {KeyboardEvent} event - Event to check the modifier flags for
    * @param {String} key - Name of key that events relates to
-   * @param {KeyEventBitmapIndex} keyEventBitmapIndex - Index of event type
+   * @param {KeyEventBitmapIndex} keyEventBitmapIndex - The bitmap index of the current
+   *        key event type
    * @protected
    */
   _checkForModifierFlagDiscrepancies(event, key, keyEventBitmapIndex) {
@@ -1126,7 +1127,8 @@ class AbstractKeyEventStrategy {
       /**
        * When a modifier key is being released (keyup), it sets its own modifier flag
        * to false. (e.g. On the keyup event for Command, the metaKey attribute is false).
-       * If this the case, we want to handle it using the main algorithm.
+       * If this the case, we want to handle it using the main algorithm and skip the
+       * reconciliation algorithm.
        */
       if (key === modifierKey && keyEventBitmapIndex === KeyEventBitmapIndex.keyup) {
         return;

--- a/src/lib/strategies/AbstractKeyEventStrategy.js
+++ b/src/lib/strategies/AbstractKeyEventStrategy.js
@@ -1111,9 +1111,11 @@ class AbstractKeyEventStrategy {
    * Synchronises the key combination history to match the modifier key flag attributes
    * on new key events
    * @param {KeyboardEvent} event - Event to check the modifier flags for
+   * @param {String} key - Name of key that events relates to
+   * @param {KeyEventBitmapIndex} keyEventBitmapIndex - Index of event type
    * @protected
    */
-  _checkForModifierFlagDiscrepancies(event) {
+  _checkForModifierFlagDiscrepancies(event, key, keyEventBitmapIndex) {
     /**
      * If a new key event is received with modifier key flags that contradict the
      * key combination history we are maintaining, we can surmise that some keyup events
@@ -1121,7 +1123,16 @@ class AbstractKeyEventStrategy {
      * We update the key combination to match the modifier flags
      */
     Object.keys(ModifierFlagsDictionary).forEach((modifierKey) => {
-       const modifierStillPressed = this._keyIsCurrentlyDown(modifierKey);
+      /**
+       * When a modifier key is being released (keyup), it sets its own modifier flag
+       * to false. (e.g. On the keyup event for Command, the metaKey attribute is false).
+       * If this the case, we want to handle it using the main algorithm.
+       */
+      if (key === modifierKey && keyEventBitmapIndex === KeyEventBitmapIndex.keyup) {
+        return;
+      }
+
+      const modifierStillPressed = this._keyIsCurrentlyDown(modifierKey);
 
        ModifierFlagsDictionary[modifierKey].forEach((attributeName) => {
          if (event[attributeName] === false && modifierStillPressed) {

--- a/src/lib/strategies/FocusOnlyKeyEventStrategy.js
+++ b/src/lib/strategies/FocusOnlyKeyEventStrategy.js
@@ -367,7 +367,7 @@ class FocusOnlyKeyEventStrategy extends AbstractKeyEventStrategy {
         `New ${describeKeyEvent(event, key, keyEventBitmapIndex)} event.`
       );
 
-      this._checkForModifierFlagDiscrepancies(event);
+      this._checkForModifierFlagDiscrepancies(event, key, keyEventBitmapIndex);
     }
 
     return EventResponse.handled;

--- a/src/lib/strategies/FocusOnlyKeyEventStrategy.js
+++ b/src/lib/strategies/FocusOnlyKeyEventStrategy.js
@@ -301,7 +301,7 @@ class FocusOnlyKeyEventStrategy extends AbstractKeyEventStrategy {
       return true;
     }
 
-    const responseAction = this._howToHandleKeyDownEvent(event,
+    const responseAction = this._howToHandleKeyEvent(event,
       focusTreeId,
       componentId,
       _key,
@@ -328,7 +328,7 @@ class FocusOnlyKeyEventStrategy extends AbstractKeyEventStrategy {
     return false;
   }
 
-  _howToHandleKeyDownEvent(event, focusTreeId, componentId, key, options, keyEventBitmapIndex){
+  _howToHandleKeyEvent(event, focusTreeId, componentId, key, options, keyEventBitmapIndex){
     if (this._shouldIgnoreEvent()) {
       this.logger.debug(
         this._logPrefix(componentId),
@@ -400,7 +400,7 @@ class FocusOnlyKeyEventStrategy extends AbstractKeyEventStrategy {
      * We first decide if the keypress event should be handled (to ensure the correct
      * order of logging statements)
      */
-    const responseAction = this._howToHandleKeyDownEvent(event,
+    const responseAction = this._howToHandleKeyEvent(event,
       focusTreeId,
       componentId,
       _key,
@@ -463,7 +463,7 @@ class FocusOnlyKeyEventStrategy extends AbstractKeyEventStrategy {
      * We first decide if the keyup event should be handled (to ensure the correct
      * order of logging statements)
      */
-    const responseAction = this._howToHandleKeyDownEvent(event,
+    const responseAction = this._howToHandleKeyEvent(event,
       focusTreeId,
       componentId,
       _key,

--- a/src/lib/strategies/GlobalKeyEventStrategy.js
+++ b/src/lib/strategies/GlobalKeyEventStrategy.js
@@ -251,9 +251,9 @@ class GlobalKeyEventStrategy extends AbstractKeyEventStrategy {
    * @param {KeyboardEvent} event - Event containing the key name and state
    */
   handleKeydown(event) {
-    this._checkForModifierFlagDiscrepancies(event);
-
     const _key = normalizeKeyName(getEventKey(event));
+
+    this._checkForModifierFlagDiscrepancies(event, _key, KeyEventBitmapIndex.keydown);
 
     const reactAppResponse = this._howReactAppRespondedTo(
       event,

--- a/test/HotKeys/BindingToKeysWithSimulatedKeypressEvents.spec.js
+++ b/test/HotKeys/BindingToKeysWithSimulatedKeypressEvents.spec.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { expect } from 'chai';
+import {mount} from 'enzyme';
+import sinon from 'sinon';
+
+import Key from '../support/Key';
+import KeyEventManager from '../../src/lib/KeyEventManager';
+import { HotKeys } from '../../src';
+import FocusableElement from '../support/FocusableElement';
+
+describe('Binding to keys with simulated keypress events:', function () {
+  context('when HotKeys has actions for a the keydown and keyup event', () => {
+    beforeEach(function () {
+      this.keyMap = {
+        'ACTION1': {sequence: 'command', action: 'keydown'},
+        'ACTION2': {sequence: 'command', action: 'keyup'},
+      };
+
+      this.action1Handler = sinon.spy();
+      this.action2Handler = sinon.spy();
+
+      this.handlers = {
+        'ACTION1': this.action1Handler,
+        'ACTION2': this.action2Handler,
+      };
+
+      this.wrapper = mount(
+        <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+          <div className="childElement" />
+        </HotKeys>
+      );
+
+      this.keyEventManager = KeyEventManager.getInstance();
+
+      this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+      this.targetElement.focus();
+    });
+
+    it('then simulates the cmd keypress event and the non-modifier key\'s keypress event (https://github.com/greena13/react-hotkeys/issues/166)', function () {
+      this.targetElement.keyDown(Key.COMMAND, { metaKey: true });
+
+      expect(this.action1Handler).to.have.been.calledOnce;
+      expect(this.action2Handler).to.not.have.been.called;
+
+      this.targetElement.keyUp(Key.COMMAND, { metaKey: false });
+
+      expect(this.action1Handler).to.have.been.calledOnce;
+      expect(this.action2Handler).to.have.been.calledOnce;
+    });
+  });
+});

--- a/test/HotKeys/BindingToKeysWithSimulatedKeypressEvents.spec.js
+++ b/test/HotKeys/BindingToKeysWithSimulatedKeypressEvents.spec.js
@@ -9,7 +9,7 @@ import { HotKeys } from '../../src';
 import FocusableElement from '../support/FocusableElement';
 
 describe('Binding to keys with simulated keypress events:', function () {
-  context('when HotKeys has actions for a the keydown and keyup event', () => {
+  context('when HotKeys has actions defined for the keydown and keyup event of the same key', () => {
     beforeEach(function () {
       this.keyMap = {
         'ACTION1': {sequence: 'command', action: 'keydown'},
@@ -36,7 +36,7 @@ describe('Binding to keys with simulated keypress events:', function () {
       this.targetElement.focus();
     });
 
-    it('then simulates the cmd keypress event and the non-modifier key\'s keypress event (https://github.com/greena13/react-hotkeys/issues/166)', function () {
+    it('then calls the handlers for both key events (https://github.com/greena13/react-hotkeys/issues/166)', function () {
       this.targetElement.keyDown(Key.COMMAND, { metaKey: true });
 
       expect(this.action1Handler).to.have.been.calledOnce;

--- a/test/support/FocusableElement.js
+++ b/test/support/FocusableElement.js
@@ -28,26 +28,26 @@ export default class FocusableElement {
   }
 
   keyDown(key, options = {}) {
-    this.element.simulate('keyDown', {key});
+    this.element.simulate('keyDown', {key, ...options});
 
     if (this.nativeElement) {
-      simulant.fire(this.nativeElement, 'keydown', {key});
+      simulant.fire(this.nativeElement, 'keydown', {key, ...options});
     }
   }
 
   keyPress(key, options = {}) {
-    this.element.simulate('keyPress', {key});
+    this.element.simulate('keyPress', {key, ...options});
 
     if (this.nativeElement) {
-      simulant.fire(this.nativeElement, 'keypress', {key});
+      simulant.fire(this.nativeElement, 'keypress', {key, ...options});
     }
   }
 
   keyUp(key, options = {}) {
-    this.element.simulate('keyUp', {key});
+    this.element.simulate('keyUp', {key, ...options});
 
     if (this.nativeElement) {
-      simulant.fire(this.nativeElement, 'keyup', {key});
+      simulant.fire(this.nativeElement, 'keyup', {key, ...options});
     }
   }
 


### PR DESCRIPTION
# Context

There is a subroutine that is run on the `keyup` event that checks the current `KeyBoardEvent`'s modifier key flags (e.g. `metaKey`) and compares it against the key state that `react-hotkeys` is maintaining. It then corrects for any discrepancies (missed key events, most likely due to a focus loss) in the `react-hotkeys` record of key state. 

On the `keyup` event for a modifier key (e.g. Command/`Meta`), its own corresponding modifier key flag  (e.g. `metaKey`) is false. This was causing registering the key as being in the `keyup` state twice, resulting in #166 whereby handlers bound to the `keyup` event of the `Meta` key were not being called.

# This pull request

* Adds additional logic to detect the exceptional case when it's a modifier key that is in the `keyup` state, and skips running the subroutine
* Adds a test that records this behaviour and should prevent regressions in the future.