### PR TITLE
Dev ignore submatches

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -262,6 +262,13 @@ export interface ConfigurationOptions {
    * any further through the Render tree).
    */
   stopEventPropagationAfterIgnoring?: boolean,
+
+  /**
+   * Whether to allow combination submatches - e.g. if there is an action bound to
+   * cmd, pressing shift+cmd will *not* trigger that action when
+   * allowCombinationSubmatches is false.
+   */
+  allowCombinationSubmatches?: boolean,
 }
 
 /**

--- a/src/helpers/resolving-handlers/isMatchPossibleBasedOnNumberOfKeys.js
+++ b/src/helpers/resolving-handlers/isMatchPossibleBasedOnNumberOfKeys.js
@@ -1,0 +1,31 @@
+import Configuration from '../../lib/Configuration';
+
+/**
+ * Whether combinationMatcher could possible match currentKeyState based on the
+ * number of keys in each. Used as a preliminary check, before the more expensive
+ * work of comparing the individual keys in each.
+ * @param {KeyCombinationRecord} keyState The current state of keys involved
+ *        in the key event.
+ * @param {ActionConfiguration} combinationMatcher Matcher to compare to the
+ *        key state
+ * @returns {boolean} True if the key state has the right amount of keys for a
+ *        match with combinationMatcher to be possible
+ * @private
+ */
+function isMatchPossibleBasedOnNumberOfKeys(keyState, combinationMatcher) {
+  const keyStateKeysNo = Object.keys(keyState.keys).length;
+  const combinationKeysNo = Object.keys(combinationMatcher.keyDictionary).length;
+
+  if (Configuration.option('allowCombinationSubmatches')) {
+    return keyStateKeysNo >= combinationKeysNo;
+  } else {
+    /**
+     * If submatches are not allow, the number of keys in the key state and the
+     * number of keys in the combination we are attempting to match, must be
+     * exactly the same
+     */
+    return keyStateKeysNo === combinationKeysNo;
+  }
+}
+
+export default isMatchPossibleBasedOnNumberOfKeys;

--- a/src/lib/Configuration.js
+++ b/src/lib/Configuration.js
@@ -99,6 +99,13 @@ const _defaultConfiguration = {
    * any further through the Render tree).
    */
   stopEventPropagationAfterIgnoring: true,
+
+  /**
+   * Whether to allow combination submatches - e.g. if there is an action bound to
+   * cmd, pressing shift+cmd will *not* trigger that action when
+   * allowCombinationSubmatches is false.
+   */
+  allowCombinationSubmatches: false,
 };
 
 const _configuration = {

--- a/src/lib/strategies/AbstractKeyEventStrategy.js
+++ b/src/lib/strategies/AbstractKeyEventStrategy.js
@@ -22,6 +22,7 @@ import Configuration from '../Configuration';
 import ModifierFlagsDictionary from '../../const/ModifierFlagsDictionary';
 import without from '../../utils/collection/without';
 import hasKeyPressEvent from '../../helpers/resolving-handlers/hasKeyPressEvent';
+import isMatchPossibleBasedOnNumberOfKeys from '../../helpers/resolving-handlers/isMatchPossibleBasedOnNumberOfKeys';
 
 /**
  * Defines common behaviour for key event strategies
@@ -974,10 +975,7 @@ class AbstractKeyEventStrategy {
               const combinationId = combinationOrder[combinationIndex];
               const combinationMatcher = matchingSequence.combinations[combinationId];
 
-              const sameNoOfKeysInCombinationAsKeyState =
-                Object.keys(currentKeyState.keys).length === Object.keys(combinationMatcher.keyDictionary).length;
-
-              if (sameNoOfKeysInCombinationAsKeyState || Configuration.option('allowCombinationSubmatches')) {
+              if (isMatchPossibleBasedOnNumberOfKeys(currentKeyState, combinationMatcher)) {
                 if (this._combinationMatchesKeys(normalizedKeyName, currentKeyState, combinationMatcher, eventBitmapIndex)) {
 
                   if (Configuration.option('allowCombinationSubmatches')) {

--- a/src/lib/strategies/AbstractKeyEventStrategy.js
+++ b/src/lib/strategies/AbstractKeyEventStrategy.js
@@ -1085,7 +1085,7 @@ class AbstractKeyEventStrategy {
 
     let keyCompletesCombination = false;
 
-    const combinationMatchesKeysPressed = !Object.keys(combinationMatch.keyDictionary).some((candidateKeyName) => {
+    const combinationMatchesKeysPressed = Object.keys(combinationMatch.keyDictionary).every((candidateKeyName) => {
       const keyState = getKeyState(keyCombination, candidateKeyName);
 
       if (keyState) {
@@ -1095,12 +1095,12 @@ class AbstractKeyEventStrategy {
               !keyAlreadyTriggeredEvent(keyState, eventBitmapIndex);
           }
 
-          return false;
-        } else {
           return true;
+        } else {
+          return false;
         }
       } else {
-        return true;
+        return false;
       }
     });
 

--- a/test/GlobalHotKeys/MatchingHotKeyCombinationsWhenAllowCombinationSubmatchesIsFalse.spec.js
+++ b/test/GlobalHotKeys/MatchingHotKeyCombinationsWhenAllowCombinationSubmatchesIsFalse.spec.js
@@ -7,7 +7,7 @@ import simulant from 'simulant';
 import KeyCode from '../support/Key';
 import {GlobalHotKeys} from '../../src';
 
-describe('Matching hotkey combinations for GlobalHotKeys:', function () {
+describe('Matching hotkey combinations for GlobalHotKeys when allowCombinationSubmatches is false:', function () {
   beforeEach(function () {
     this.parentDiv = document.createElement('div');
     this.reactDiv = document.createElement('div');
@@ -335,11 +335,9 @@ describe('Matching hotkey combinations for GlobalHotKeys:', function () {
               simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.C });
             });
 
-            it('then calls the shorter combination\'s handler followed by the longer combination\'s handler', function() {
-              expect(this.comboHandler).to.have.been.calledOnce;
+            it('then calls the longer combination\'s handler only', function() {
+              expect(this.comboHandler).to.not.have.been.called;
               expect(this.longerCombinationHandler).to.have.been.calledOnce;
-
-              expect(this.comboHandler).to.have.been.calledBefore(this.longerCombinationHandler);
             });
           });
 
@@ -541,5 +539,4 @@ describe('Matching hotkey combinations for GlobalHotKeys:', function () {
       });
     })
   });
-
 });

--- a/test/GlobalHotKeys/MatchingHotKeyCombinationsWhenAllowCombinationSubmatchesIsTrue.spec.js
+++ b/test/GlobalHotKeys/MatchingHotKeyCombinationsWhenAllowCombinationSubmatchesIsTrue.spec.js
@@ -1,0 +1,552 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {expect} from 'chai';
+import sinon from 'sinon';
+import simulant from 'simulant';
+
+import KeyCode from '../support/Key';
+import { configure, GlobalHotKeys } from '../../src';
+
+describe('Matching hotkey combinations for GlobalHotKeys when allowCombinationSubmatches is true:', function () {
+  before(function(){
+    configure({allowCombinationSubmatches: true });
+  });
+
+  after(function() {
+    configure({allowCombinationSubmatches: false });
+  });
+
+  beforeEach(function () {
+    this.parentDiv = document.createElement('div');
+    this.reactDiv = document.createElement('div');
+
+    document.body.appendChild(this.parentDiv);
+    this.parentDiv.appendChild(this.reactDiv);
+  });
+
+  afterEach(function() {
+    document.body.removeChild(this.parentDiv);
+  });
+
+  describe('when the actions are triggered by the keydown event', function () {
+    beforeEach(function () {
+      this.keyMap = {
+        'COMBO1': { sequence: 'a+b', action: 'keydown' },
+        'COMBO2': { sequence: 'a+b+c', action: 'keydown' },
+      };
+
+      this.comboHandler = sinon.spy();
+      this.longerCombinationHandler = sinon.spy();
+
+      const handlers = {
+        'COMBO1': this.comboHandler,
+        'COMBO2': this.longerCombinationHandler,
+      };
+
+      this.wrapper = mount(
+        <div >
+          <GlobalHotKeys keyMap={this.keyMap} handlers={handlers}>
+            <div className="childElement" />
+          </GlobalHotKeys>
+
+          <div className="siblingElement" />
+        </div>,
+        { attachTo: this.reactDiv }
+      );
+    });
+
+    describe('and the first key is pressed and held', function () {
+      describe('and the keydown event for the second key in the combination occurs', () => {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+        });
+
+        it('then calls the key combination\'s handler', function() {
+          expect(this.comboHandler).to.have.been.calledOnce;
+        });
+      });
+
+      describe('and the keypress event for the second key in the combination occurs', () => {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+        });
+
+        it('then does NOT call the key combination\'s handler again', function() {
+          expect(this.comboHandler).to.have.been.calledOnce;
+        });
+      });
+
+      describe('and the keyup event for the second key in the combination occurs', () => {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.B });
+
+          simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+        });
+
+        it('then does NOT call the key combination\'s handler again', function() {
+          expect(this.comboHandler).to.have.been.calledOnce;
+        });
+      });
+    });
+
+    describe('and there is a combination that is a subset of a longer one', () => {
+      describe('and the keys have been pressed to satisfy the shorter combination without releasing the keys', () => {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+        });
+
+        it('then calls the shorter key combination\'s handler', function() {
+          expect(this.comboHandler).to.have.been.calledOnce;
+          expect(this.longerCombinationHandler).to.not.have.been.called;
+        });
+
+        describe('and the remaining keys to satisfy the longer combination are pressed', () => {
+          beforeEach(function () {
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.C });
+            simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.C });
+          });
+
+          it('then calls the longer key combination\'s handler', function() {
+            expect(this.longerCombinationHandler).to.have.been.calledOnce;
+          });
+        });
+      });
+    });
+  });
+
+  describe('when the actions are triggered by the keypress event', function () {
+    beforeEach(function () {
+      this.keyMap = {
+        'COMBO1': { sequence: 'a+b', action: 'keypress' },
+        'COMBO2': { sequence: 'a+b+c', action: 'keypress' },
+      };
+
+      this.comboHandler = sinon.spy();
+      this.longerCombinationHandler = sinon.spy();
+
+      const handlers = {
+        'COMBO1': this.comboHandler,
+        'COMBO2': this.longerCombinationHandler,
+      };
+
+      this.wrapper = mount(
+        <div >
+          <GlobalHotKeys keyMap={this.keyMap} handlers={handlers}>
+            <div className="childElement" />
+          </GlobalHotKeys>
+
+          <div className="siblingElement" />
+        </div>,
+        { attachTo: this.reactDiv }
+      );
+    });
+
+    describe('and the first key is pressed and held', function () {
+      describe('and the keydown event for the second key in the combination occurs', () => {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+        });
+
+        it('then no handlers are called', function() {
+          expect(this.comboHandler).to.not.have.been.called;
+        });
+      });
+
+      describe('and the keypress event for the second key in the combination occurs', () => {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+        });
+
+        it('then calls the key combination\'s handler', function() {
+          expect(this.comboHandler).to.have.been.calledOnce;
+        });
+      });
+
+      describe('and the keyup event for the second key in the combination occurs', () => {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.B });
+
+          simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+        });
+
+        it('then does NOT call the key combination\'s handler again', function() {
+          expect(this.comboHandler).to.have.been.calledOnce;
+        });
+      });
+
+      describe('and there is a combination that is a subset of a longer one', () => {
+        describe('and the keys have been pressed to satisfy the shorter combination without releasing the keys', () => {
+          beforeEach(function () {
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+            simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+            simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+          });
+
+          it('then calls the shorter key combination\'s handler', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+            expect(this.longerCombinationHandler).to.not.have.been.called;
+          });
+
+          describe('and the remaining keys to satisfy the longer combination are pressed', () => {
+            beforeEach(function () {
+              simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.C });
+              simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.C });
+            });
+
+            it('then calls the longer key combination\'s handler', function() {
+              expect(this.longerCombinationHandler).to.have.been.calledOnce;
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('when the actions are triggered by the keyup event', function () {
+    beforeEach(function () {
+      this.keyMap = {
+        'COMBO1': { sequence: 'a+b', action: 'keyup' },
+        'COMBO2': { sequence: 'a+b+c', action: 'keyup' },
+      };
+
+      this.comboHandler = sinon.spy();
+      this.longerCombinationHandler = sinon.spy();
+
+      const handlers = {
+        'COMBO1': this.comboHandler,
+        'COMBO2': this.longerCombinationHandler,
+      };
+
+      this.wrapper = mount(
+        <GlobalHotKeys keyMap={this.keyMap} handlers={handlers}>
+          <div className="childElement" />
+        </GlobalHotKeys>,
+        { attachTo: this.reactDiv }
+      );
+    });
+
+    describe('and the first key is pressed and held', function () {
+      describe('and the keydown event for the second key in the combination occurs', () => {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+        });
+
+        it('then no handlers are called', function() {
+          expect(this.comboHandler).to.not.have.been.called;
+        });
+      });
+
+      describe('and the keypress event for the second key in the combination occurs', () => {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+        });
+
+        it('then no handlers are called', function() {
+          expect(this.comboHandler).to.not.have.been.called;
+        });
+      });
+
+      describe('and the keyup event for the second key in the combination occurs', () => {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.B });
+
+          simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+        });
+
+        it('then calls the key combination\'s handler', function() {
+          expect(this.comboHandler).to.have.been.calledOnce;
+        });
+      });
+    });
+
+    describe('and there is a combination that is a subset of a longer one', () => {
+      describe('and the keys have been pressed to satisfy the shorter combination without releasing the keys', () => {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+        });
+
+        it('then no handlers are called', function() {
+          expect(this.comboHandler).to.not.have.been.called;
+        });
+
+        describe('and the remaining keys to satisfy the longer combination are pressed', () => {
+          beforeEach(function () {
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.C });
+            simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.C });
+          });
+
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+
+          describe('and a key in both combinations is released', function () {
+            beforeEach(function () {
+              simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+            });
+
+            it('then no handlers are called', function() {
+              expect(this.comboHandler).to.not.have.been.called;
+            });
+          });
+
+          describe('and all the keys in the shorter combination are released followed by the key only in the longer combination', function () {
+            beforeEach(function () {
+              simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+              simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.B });
+
+              simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.C });
+            });
+
+            it('then calls the shorter combination\'s handler followed by the longer combination\'s handler', function() {
+              expect(this.comboHandler).to.have.been.calledOnce;
+              expect(this.longerCombinationHandler).to.have.been.calledOnce;
+
+              expect(this.comboHandler).to.have.been.calledBefore(this.longerCombinationHandler);
+            });
+          });
+
+          describe('and all the keys are released with the key only in the longer combination released first', function () {
+            beforeEach(function () {
+              simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.C });
+
+              simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+              simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.B });
+            });
+
+            it('then calls the longer combination\'s handler only', function() {
+              expect(this.comboHandler).to.not.have.been.called;
+              expect(this.longerCombinationHandler).to.have.been.calledOnce;
+            });
+          });
+
+          describe('and all the keys are released in an order that doesn\'t match the shorter combination', function () {
+            beforeEach(function () {
+              simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+              simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.C });
+              simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.B });
+
+            });
+
+            it('then calls the longer combination\'s handler only', function() {
+              expect(this.comboHandler).to.not.have.been.called;
+              expect(this.longerCombinationHandler).to.have.been.calledOnce;
+            });
+          });
+        });
+      });
+    })
+  });
+
+  [
+    'keydown',
+    'keypress',
+    'keyup'
+  ].forEach((keyEvent) => {
+    describe(`when the actions are triggered by the ${keyEvent} event`, () => {
+      beforeEach(function () {
+        this.keyMap = {
+          'COMBO1': { sequence: 'a+b', action: keyEvent },
+          'COMBO2': { sequence: 'a+b+c', action: keyEvent },
+        };
+
+        this.comboHandler = sinon.spy();
+        this.longerCombinationHandler = sinon.spy();
+
+        const handlers = {
+          'COMBO1': this.comboHandler,
+          'COMBO2': this.longerCombinationHandler,
+        };
+
+        this.wrapper = mount(
+          <div >
+            <GlobalHotKeys keyMap={this.keyMap} handlers={handlers}>
+              <div className="childElement" />
+            </GlobalHotKeys>
+
+            <div className="siblingElement" />
+          </div>,
+          { attachTo: this.reactDiv }
+        );
+      });
+
+      describe('and NO key events have occurred', function () {
+        it('then no handlers are called', function() {
+          expect(this.comboHandler).to.not.have.been.called;
+        });
+      });
+
+      describe('and the first key in the combination is pressed and released', function () {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+        });
+
+        it('then no handlers are called', function() {
+          expect(this.comboHandler).to.not.have.been.called;
+        });
+      });
+
+      describe('and the second key in the combination is pressed after the first is released', function () {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.B });
+        });
+
+        it('then no handlers are called', function() {
+          expect(this.comboHandler).to.not.have.been.called;
+        });
+      });
+
+      describe('and the keys involved in the combination are released in an order different to how they appear in the combination', () => {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+          simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+        });
+
+        it('then calls the key combination\'s handler', function() {
+          expect(this.comboHandler).to.have.been.calledOnce;
+        });
+      });
+
+      describe('and the keys are released in an order different than when they are pressed', () => {
+        beforeEach(function () {
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+          simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+
+          simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.B });
+          simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+        });
+
+        it('then calls the key combination\'s handler', function() {
+          expect(this.comboHandler).to.have.been.calledOnce;
+        });
+      });
+
+      describe('and the combination is used twice', () => {
+        beforeEach(function () {
+          for(let i = 0; i < 2; i++) {
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+            simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+            simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+
+            simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.B });
+            simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+          }
+        });
+
+        it('then calls the key combination\'s handler twice', function() {
+          expect(this.comboHandler).to.have.been.calledTwice;
+        });
+      });
+
+      describe('and a key not in the combination is already held down', () => {
+
+        describe('and released afterwards', () => {
+          beforeEach(function () {
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+            simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+            simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+            simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+
+            simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.B });
+            simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+
+            simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+          });
+
+          it('then calls the key combination\'s handler', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
+        });
+
+        describe('and released in the middle of the combination', () => {
+          beforeEach(function () {
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.ENTER });
+
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+            simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+            simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.ENTER });
+
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+            simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+
+            simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.B });
+            simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+          });
+
+          it('then calls the key combination\'s handler', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
+        });
+      });
+    })
+  });
+});

--- a/test/HotKeys/MatchingSingleHotKeysWhenAllowCombinationSubmatchesIsFalse.spec.js
+++ b/test/HotKeys/MatchingSingleHotKeysWhenAllowCombinationSubmatchesIsFalse.spec.js
@@ -8,7 +8,7 @@ import FocusableElement from '../support/FocusableElement';
 import KeyCode from '../support/Key';
 import {HotKeys} from '../../src/';
 
-describe('Matching single hotkeys:', function () {
+describe('Matching single hotkeys when allowCombinationSubmatches is false:', function () {
   describe('when the actions are triggered by the keypress event', () => {
     beforeEach(function () {
       this.keyMap = {
@@ -133,7 +133,7 @@ describe('Matching single hotkeys:', function () {
 
     describe('when one hotkey is pressed down and then another', function () {
       describe('and the first hotkey is released and then the second', () => {
-        it('then the first hotkey\'s handler is called followed by the second hotkey\'s', function() {
+        it('then the first hotkey\'s handler is called but NOT the second hotkey\'s', function() {
           this.targetElement.keyDown(KeyCode.A);
           this.targetElement.keyPress(KeyCode.A);
 
@@ -144,18 +144,18 @@ describe('Matching single hotkeys:', function () {
           this.targetElement.keyPress(KeyCode.B);
 
           expect(this.action1Handler).to.have.been.calledOnce;
-          expect(this.action2Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
 
           this.targetElement.keyUp(KeyCode.A);
           this.targetElement.keyUp(KeyCode.B);
 
           expect(this.action1Handler).to.have.been.calledOnce;
-          expect(this.action2Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
         });
       });
 
       describe('and the second hotkey is released and then the first', () => {
-        it('then the first hotkey\'s handler is called followed by the second hotkey\'s', function() {
+        it('then the first hotkey\'s handler is called but NOT the second hotkey\'s', function() {
           this.targetElement.keyDown(KeyCode.A);
           this.targetElement.keyPress(KeyCode.A);
 
@@ -166,13 +166,13 @@ describe('Matching single hotkeys:', function () {
           this.targetElement.keyPress(KeyCode.B);
 
           expect(this.action1Handler).to.have.been.calledOnce;
-          expect(this.action2Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
 
           this.targetElement.keyUp(KeyCode.B);
           this.targetElement.keyUp(KeyCode.A);
 
           expect(this.action1Handler).to.have.been.calledOnce;
-          expect(this.action2Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
         });
       });
     });
@@ -352,7 +352,7 @@ describe('Matching single hotkeys:', function () {
 
     describe('when one hotkey is pressed down and then another', function () {
       describe('and the first hotkey is released and then the second', () => {
-        it('then the first hotkey\'s handler is called followed by the second hotkey\'s', function() {
+        it('then the first hotkey\'s handler is called but not the second hotkey\'s', function() {
           this.targetElement.keyDown(KeyCode.A);
           this.targetElement.keyPress(KeyCode.A);
 
@@ -363,18 +363,18 @@ describe('Matching single hotkeys:', function () {
           this.targetElement.keyPress(KeyCode.B);
 
           expect(this.action1Handler).to.have.been.calledOnce;
-          expect(this.action2Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
 
           this.targetElement.keyUp(KeyCode.A);
           this.targetElement.keyUp(KeyCode.B);
 
           expect(this.action1Handler).to.have.been.calledOnce;
-          expect(this.action2Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
         });
       });
 
       describe('and the second hotkey is released and then the first', () => {
-        it('then the first hotkey\'s handler is called followed by the second hotkey\'s', function() {
+        it('then the first hotkey\'s handler is called but NOT the second hotkey\'s', function() {
           this.targetElement.keyDown(KeyCode.A);
           this.targetElement.keyPress(KeyCode.A);
 
@@ -385,13 +385,13 @@ describe('Matching single hotkeys:', function () {
           this.targetElement.keyPress(KeyCode.B);
 
           expect(this.action1Handler).to.have.been.calledOnce;
-          expect(this.action2Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
 
           this.targetElement.keyUp(KeyCode.B);
           this.targetElement.keyUp(KeyCode.A);
 
           expect(this.action1Handler).to.have.been.calledOnce;
-          expect(this.action2Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
         });
       });
     });
@@ -569,7 +569,7 @@ describe('Matching single hotkeys:', function () {
 
     describe('when one hotkey is pressed down and then another', function () {
       describe('and the first hotkey is released and then the second', () => {
-        it('then the first hotkey\'s handler is called followed by the second hotkey\'s', function() {
+        it('then neither hotkeys\' handler is called', function() {
           this.targetElement.keyDown(KeyCode.A);
           this.targetElement.keyPress(KeyCode.A);
 
@@ -581,18 +581,18 @@ describe('Matching single hotkeys:', function () {
 
           this.targetElement.keyUp(KeyCode.A);
 
-          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action1Handler).to.not.have.been.called;
           expect(this.action2Handler).to.not.have.been.called;
 
           this.targetElement.keyUp(KeyCode.B);
 
-          expect(this.action1Handler).to.have.been.calledOnce;
-          expect(this.action2Handler).to.have.been.calledOnce;
+          expect(this.action1Handler).to.not.have.been.called;
+          expect(this.action2Handler).to.not.have.been.called;
         });
       });
 
       describe('and the second hotkey is released and then the first', () => {
-        it('then the second hotkey\'s handler is called followed by the first hotkey\'s', function() {
+        it('then neither hotkeys\' handler is called', function() {
           this.targetElement.keyDown(KeyCode.A);
           this.targetElement.keyPress(KeyCode.A);
 
@@ -604,20 +604,20 @@ describe('Matching single hotkeys:', function () {
 
           this.targetElement.keyUp(KeyCode.B);
 
-          expect(this.action2Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
           expect(this.action1Handler).to.not.have.been.called;
 
           this.targetElement.keyUp(KeyCode.A);
 
-          expect(this.action2Handler).to.have.been.calledOnce;
-          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+          expect(this.action1Handler).to.not.have.been.called;
         });
       });
     });
 
     describe('when one hotkey is pressed down, followed by a non-hotkey', function () {
       describe('and the hotkey is released and then the non-hotkey', () => {
-        it('then the hotkey\'s handler is called', function() {
+        it('then the hotkey\'s handler is NOT called', function() {
           this.targetElement.keyDown(KeyCode.A);
           this.targetElement.keyPress(KeyCode.A);
 
@@ -628,18 +628,18 @@ describe('Matching single hotkeys:', function () {
 
           this.targetElement.keyUp(KeyCode.A);
 
-          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action1Handler).to.not.have.been.called;
           expect(this.action2Handler).to.not.have.been.called;
 
           this.targetElement.keyUp(KeyCode.ENTER);
 
-          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action1Handler).to.not.have.been.called;
           expect(this.action2Handler).to.not.have.been.called;
         });
       });
 
       describe('and the non-hotkey is released and then the hotkey', () => {
-        it('then the hotkey\'s handler is called', function() {
+        it('then the hotkey\'s handler is NOT called', function() {
           this.targetElement.keyDown(KeyCode.A);
           this.targetElement.keyPress(KeyCode.A);
 
@@ -651,7 +651,7 @@ describe('Matching single hotkeys:', function () {
 
           this.targetElement.keyUp(KeyCode.A);
 
-          expect(this.action1Handler).to.have.been.called;
+          expect(this.action1Handler).to.not.have.been.called;
           expect(this.action2Handler).to.not.have.been.called;
         });
       });

--- a/test/HotKeys/MatchingSingleHotKeysWhenAllowCombinationSubmatchesIsTrue.spec.js
+++ b/test/HotKeys/MatchingSingleHotKeysWhenAllowCombinationSubmatchesIsTrue.spec.js
@@ -1,0 +1,668 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {expect} from 'chai';
+import sinon from 'sinon';
+
+import FocusableElement from '../support/FocusableElement';
+
+import KeyCode from '../support/Key';
+import { configure, HotKeys } from '../../src/';
+
+describe('Matching single hotkeys when allowCombinationSubmatches is true:', function () {
+  before(function(){
+    configure({allowCombinationSubmatches: true });
+  });
+
+  after(function() {
+    configure({allowCombinationSubmatches: false });
+  });
+
+  describe('when the actions are triggered by the keypress event', () => {
+    beforeEach(function () {
+      this.keyMap = {
+        'ACTION1': 'a',
+        'ACTION2': 'b',
+      };
+
+      this.action1Handler = sinon.spy();
+      this.action2Handler = sinon.spy();
+
+      const handlers = {
+        'ACTION1': this.action1Handler,
+        'ACTION2': this.action2Handler,
+      };
+
+      this.wrapper = mount(
+        <div >
+          <HotKeys keyMap={this.keyMap} handlers={handlers}>
+            <div className="childElement" />
+          </HotKeys>
+
+          <div className="siblingElement" />
+        </div>
+      );
+
+      this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+      this.targetElement.focus();
+    });
+
+    describe('when NO key events have occurred', function () {
+      it('then no handlers are called', function() {
+        expect(this.action1Handler).to.not.have.been.called;
+      });
+    });
+
+    describe('when a hot key keydown event occurs', function () {
+      beforeEach(function () {
+        this.targetElement.keyDown(KeyCode.A);
+      });
+
+      it('then the matching handler is called once', function() {
+        expect(this.action1Handler).to.have.been.calledOnce;
+      });
+    });
+
+    describe('when a hotkey keypress event occurs', function () {
+      beforeEach(function () {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+      });
+
+      it('then the matching handler is not called again', function() {
+        expect(this.action1Handler).to.have.been.calledOnce;
+      });
+    });
+
+    describe('when a hotkey keyup event occurs', function () {
+      beforeEach(function () {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
+      });
+
+      it('then the matching handler is not called again', function() {
+        expect(this.action1Handler).to.have.been.calledOnce;
+      });
+    });
+
+    describe('when a particular hotkey is pressed twice', function () {
+      beforeEach(function () {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
+      });
+
+      it('then the matching handler is called again on the second keypress', function() {
+        expect(this.action1Handler).to.have.been.calledOnce;
+
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
+
+        expect(this.action1Handler).to.have.been.calledTwice;
+      });
+    });
+
+    describe('when one hotkey is pressed and then another', function () {
+      it('then the first hotkey\'s handler is called followed by the second hotkey\'s', function() {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
+
+        expect(this.action1Handler).to.have.been.calledOnce;
+        expect(this.action2Handler).to.not.have.been.called;
+
+        this.targetElement.keyDown(KeyCode.B);
+        this.targetElement.keyPress(KeyCode.B);
+        this.targetElement.keyUp(KeyCode.B);
+
+        expect(this.action1Handler).to.have.been.calledOnce;
+        expect(this.action2Handler).to.have.been.calledOnce;
+      });
+    });
+
+    describe('when one hotkey is pressed and then a non-hotkey', function () {
+      it('then the hotkey\'s handler is called', function() {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
+
+        expect(this.action1Handler).to.have.been.calledOnce;
+        expect(this.action2Handler).to.not.have.been.called;
+
+        this.targetElement.keyDown(KeyCode.C);
+        this.targetElement.keyPress(KeyCode.C);
+        this.targetElement.keyUp(KeyCode.C);
+
+        expect(this.action1Handler).to.have.been.calledOnce;
+        expect(this.action2Handler).to.not.have.been.called;
+      });
+    });
+
+    describe('when one hotkey is pressed down and then another', function () {
+      describe('and the first hotkey is released and then the second', () => {
+        it('then the first hotkey\'s handler is called followed by the second hotkey\'s', function() {
+          this.targetElement.keyDown(KeyCode.A);
+          this.targetElement.keyPress(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyDown(KeyCode.B);
+          this.targetElement.keyPress(KeyCode.B);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.have.been.calledOnce;
+
+          this.targetElement.keyUp(KeyCode.A);
+          this.targetElement.keyUp(KeyCode.B);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.have.been.calledOnce;
+        });
+      });
+
+      describe('and the second hotkey is released and then the first', () => {
+        it('then the first hotkey\'s handler is called followed by the second hotkey\'s', function() {
+          this.targetElement.keyDown(KeyCode.A);
+          this.targetElement.keyPress(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyDown(KeyCode.B);
+          this.targetElement.keyPress(KeyCode.B);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.have.been.calledOnce;
+
+          this.targetElement.keyUp(KeyCode.B);
+          this.targetElement.keyUp(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.have.been.calledOnce;
+        });
+      });
+    });
+
+    describe('when one hotkey is pressed down and then a non-hotkey', function () {
+      describe('and the hotkey is released and then the non-hotkey', () => {
+        it('then the hotkey\'s handler is called', function() {
+          this.targetElement.keyDown(KeyCode.A);
+          this.targetElement.keyPress(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyDown(KeyCode.C);
+          this.targetElement.keyPress(KeyCode.C);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyUp(KeyCode.A);
+          this.targetElement.keyUp(KeyCode.C);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+        });
+      });
+
+      describe('and the non-hotkey is released and then the hotkey', () => {
+        it('then the hotkey\'s handler is called', function() {
+          this.targetElement.keyDown(KeyCode.A);
+          this.targetElement.keyPress(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyDown(KeyCode.C);
+          this.targetElement.keyPress(KeyCode.C);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyUp(KeyCode.C);
+          this.targetElement.keyUp(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+        });
+      });
+    });
+  });
+
+  describe('when the actions are triggered by the keydown event', () => {
+    beforeEach(function () {
+      this.keyMap = {
+        'ACTION1': { sequence: 'a', action: 'keydown' },
+        'ACTION2': { sequence: 'b', action: 'keydown' }
+      };
+
+      this.action1Handler = sinon.spy();
+      this.action2Handler = sinon.spy();
+
+      const handlers = {
+        'ACTION1': this.action1Handler,
+        'ACTION2': this.action2Handler,
+      };
+
+      this.wrapper = mount(
+        <div >
+          <HotKeys keyMap={this.keyMap} handlers={handlers}>
+            <div className="childElement" />
+          </HotKeys>
+
+          <div className="siblingElement" />
+        </div>
+      );
+
+      this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+      this.targetElement.focus();
+    });
+
+    describe('when NO key events have occurred', function () {
+      it('then no handlers are called', function() {
+        expect(this.action1Handler).to.not.have.been.called;
+      });
+    });
+
+    describe('when a hot key keydown event occurs', function () {
+      beforeEach(function () {
+        this.targetElement.keyDown(KeyCode.A);
+      });
+
+      it('then the matching handler is called once', function() {
+        expect(this.action1Handler).to.have.been.calledOnce;
+      });
+    });
+
+    describe('when a hotkey keypress event occurs', function () {
+      beforeEach(function () {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+      });
+
+      it('then the matching handler is called', function() {
+        expect(this.action1Handler).to.have.been.calledOnce;
+      });
+    });
+
+    describe('when a hotkey keyup event occurs', function () {
+      beforeEach(function () {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
+      });
+
+      it('then the matching handler is NOT called again', function() {
+        expect(this.action1Handler).to.have.been.calledOnce;
+      });
+    });
+
+    describe('when a particular hotkey is pressed twice', function () {
+      beforeEach(function () {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
+
+      });
+
+      it('then the matching handler is called again on the second keydown', function() {
+        expect(this.action1Handler).to.have.been.calledOnce;
+
+        this.targetElement.keyDown(KeyCode.A);
+
+        expect(this.action1Handler).to.have.been.calledTwice;
+
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
+
+        expect(this.action1Handler).to.have.been.calledTwice;
+      });
+    });
+
+    describe('when one hotkey is pressed and then another', function () {
+      it('then the first hotkey\'s handler is called followed by the second hotkey\'s', function() {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
+
+        expect(this.action1Handler).to.have.been.calledOnce;
+        expect(this.action2Handler).to.not.have.been.called;
+
+        this.targetElement.keyDown(KeyCode.B);
+        this.targetElement.keyPress(KeyCode.B);
+        this.targetElement.keyUp(KeyCode.B);
+
+        expect(this.action1Handler).to.have.been.calledOnce;
+        expect(this.action2Handler).to.have.been.calledOnce;
+      });
+    });
+
+    describe('when one hotkey is pressed and then a non-hotkey', function () {
+      it('then the hotkey\'s handler is called', function() {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
+
+        expect(this.action1Handler).to.have.been.calledOnce;
+        expect(this.action2Handler).to.not.have.been.called;
+
+        this.targetElement.keyDown(KeyCode.C);
+        this.targetElement.keyPress(KeyCode.C);
+        this.targetElement.keyUp(KeyCode.C);
+
+        expect(this.action1Handler).to.have.been.calledOnce;
+        expect(this.action2Handler).to.not.have.been.called;
+      });
+    });
+
+    describe('when one hotkey is pressed down and then another', function () {
+      describe('and the first hotkey is released and then the second', () => {
+        it('then the first hotkey\'s handler is called followed by the second hotkey\'s', function() {
+          this.targetElement.keyDown(KeyCode.A);
+          this.targetElement.keyPress(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyDown(KeyCode.B);
+          this.targetElement.keyPress(KeyCode.B);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.have.been.calledOnce;
+
+          this.targetElement.keyUp(KeyCode.A);
+          this.targetElement.keyUp(KeyCode.B);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.have.been.calledOnce;
+        });
+      });
+
+      describe('and the second hotkey is released and then the first', () => {
+        it('then the first hotkey\'s handler is called followed by the second hotkey\'s', function() {
+          this.targetElement.keyDown(KeyCode.A);
+          this.targetElement.keyPress(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyDown(KeyCode.B);
+          this.targetElement.keyPress(KeyCode.B);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.have.been.calledOnce;
+
+          this.targetElement.keyUp(KeyCode.B);
+          this.targetElement.keyUp(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.have.been.calledOnce;
+        });
+      });
+    });
+
+    describe('when one hotkey is pressed down and then a non-hotkey', function () {
+      describe('and the hotkey is released and then the non-hotkey', () => {
+        it('then the hotkey\'s handler is called', function() {
+          this.targetElement.keyDown(KeyCode.A);
+          this.targetElement.keyPress(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyDown(KeyCode.C);
+          this.targetElement.keyPress(KeyCode.C);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyUp(KeyCode.A);
+          this.targetElement.keyUp(KeyCode.C);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+        });
+      });
+
+      describe('and the non-hotkey is released and then the hotkey', () => {
+        it('then the hotkey\'s handler is called', function() {
+          this.targetElement.keyDown(KeyCode.A);
+          this.targetElement.keyPress(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyDown(KeyCode.C);
+          this.targetElement.keyPress(KeyCode.C);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyUp(KeyCode.C);
+          this.targetElement.keyUp(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+        });
+      });
+    });
+  });
+
+  describe('when the actions are triggered by the keyup event', () => {
+    beforeEach(function () {
+      this.keyMap = {
+        'ACTION1': { sequence: 'a', action: 'keyup' },
+        'ACTION2': { sequence: 'b', action: 'keyup' }
+      };
+
+      this.action1Handler = sinon.spy();
+      this.action2Handler = sinon.spy();
+
+      const handlers = {
+        'ACTION1': this.action1Handler,
+        'ACTION2': this.action2Handler,
+      };
+
+      this.wrapper = mount(
+        <div >
+          <HotKeys keyMap={this.keyMap} handlers={handlers}>
+            <div className="childElement" />
+          </HotKeys>
+
+          <div className="siblingElement" />
+        </div>
+      );
+
+      this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+      this.targetElement.focus();
+    });
+
+    describe('when NO key events have occurred', function () {
+      it('then no handlers are called', function() {
+        expect(this.action1Handler).to.not.have.been.called;
+      });
+    });
+
+    describe('when a hot key keydown event occurs', function () {
+      beforeEach(function () {
+        this.targetElement.keyDown(KeyCode.A);
+      });
+
+      it('then no handlers are called', function() {
+        expect(this.action1Handler).to.not.have.been.called;
+      });
+    });
+
+    describe('when a hotkey keypress event occurs', function () {
+      beforeEach(function () {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+      });
+
+      it('then no handlers are called', function() {
+        expect(this.action1Handler).to.not.have.been.called;
+      });
+    });
+
+    describe('when a hotkey keyup event occurs', function () {
+      beforeEach(function () {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
+      });
+
+      it('then the matching handler is called', function() {
+        expect(this.action1Handler).to.have.been.calledOnce;
+      });
+    });
+
+    describe('when a particular hotkey is pressed twice', function () {
+      beforeEach(function () {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
+
+      });
+
+      it('then the matching handler is called again on the second keyup', function() {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+
+        expect(this.action1Handler).to.have.been.calledOnce;
+
+        this.targetElement.keyUp(KeyCode.A);
+
+        expect(this.action1Handler).to.have.been.calledTwice;
+      });
+    });
+
+    describe('when one hotkey is pressed and then another', function () {
+      it('then the first hotkey\'s handler is called followed by the second hotkey\'s', function() {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
+
+        expect(this.action1Handler).to.have.been.calledOnce;
+        expect(this.action2Handler).to.not.have.been.called;
+
+        this.targetElement.keyDown(KeyCode.B);
+        this.targetElement.keyPress(KeyCode.B);
+        this.targetElement.keyUp(KeyCode.B);
+
+        expect(this.action1Handler).to.have.been.calledOnce;
+        expect(this.action2Handler).to.have.been.calledOnce;
+      });
+    });
+
+    describe('when one hotkey is pressed and then a non-hotkey', function () {
+      it('then the first hotkey\'s handler is called', function() {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
+
+        expect(this.action1Handler).to.have.been.calledOnce;
+        expect(this.action2Handler).to.not.have.been.called;
+
+        this.targetElement.keyDown(KeyCode.C);
+        this.targetElement.keyPress(KeyCode.C);
+        this.targetElement.keyUp(KeyCode.C);
+
+        expect(this.action1Handler).to.have.been.calledOnce;
+        expect(this.action2Handler).to.not.have.been.called;
+      });
+    });
+
+    describe('when one hotkey is pressed down and then another', function () {
+      describe('and the first hotkey is released and then the second', () => {
+        it('then the first hotkey\'s handler is called followed by the second hotkey\'s', function() {
+          this.targetElement.keyDown(KeyCode.A);
+          this.targetElement.keyPress(KeyCode.A);
+
+          expect(this.action1Handler).to.not.have.been.called;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyDown(KeyCode.B);
+          this.targetElement.keyPress(KeyCode.B);
+
+          this.targetElement.keyUp(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyUp(KeyCode.B);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.have.been.calledOnce;
+        });
+      });
+
+      describe('and the second hotkey is released and then the first', () => {
+        it('then the second hotkey\'s handler is called followed by the first hotkey\'s', function() {
+          this.targetElement.keyDown(KeyCode.A);
+          this.targetElement.keyPress(KeyCode.A);
+
+          expect(this.action1Handler).to.not.have.been.called;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyDown(KeyCode.B);
+          this.targetElement.keyPress(KeyCode.B);
+
+          this.targetElement.keyUp(KeyCode.B);
+
+          expect(this.action2Handler).to.have.been.calledOnce;
+          expect(this.action1Handler).to.not.have.been.called;
+
+          this.targetElement.keyUp(KeyCode.A);
+
+          expect(this.action2Handler).to.have.been.calledOnce;
+          expect(this.action1Handler).to.have.been.calledOnce;
+        });
+      });
+    });
+
+    describe('when one hotkey is pressed down, followed by a non-hotkey', function () {
+      describe('and the hotkey is released and then the non-hotkey', () => {
+        it('then the hotkey\'s handler is called', function() {
+          this.targetElement.keyDown(KeyCode.A);
+          this.targetElement.keyPress(KeyCode.A);
+
+          expect(this.action1Handler).to.not.have.been.called;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyDown(KeyCode.ENTER);
+
+          this.targetElement.keyUp(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyUp(KeyCode.ENTER);
+
+          expect(this.action1Handler).to.have.been.calledOnce;
+          expect(this.action2Handler).to.not.have.been.called;
+        });
+      });
+
+      describe('and the non-hotkey is released and then the hotkey', () => {
+        it('then the hotkey\'s handler is called', function() {
+          this.targetElement.keyDown(KeyCode.A);
+          this.targetElement.keyPress(KeyCode.A);
+
+          this.targetElement.keyDown(KeyCode.ENTER);
+          this.targetElement.keyUp(KeyCode.ENTER);
+
+          expect(this.action1Handler).to.not.have.been.called;
+          expect(this.action2Handler).to.not.have.been.called;
+
+          this.targetElement.keyUp(KeyCode.A);
+
+          expect(this.action1Handler).to.have.been.called;
+          expect(this.action2Handler).to.not.have.been.called;
+        });
+      });
+    });
+  });
+});

--- a/test/HotKeys/focus-only/ChangingKeyMapAndHandlersAfterMount.spec.js
+++ b/test/HotKeys/focus-only/ChangingKeyMapAndHandlersAfterMount.spec.js
@@ -40,10 +40,14 @@ describe('Changing keyMap and handlers after mount:', function () {
 
       it('then the new sequence is ignored', function() {
         this.targetElement.keyDown(KeyCode.B);
+        this.targetElement.keyPress(KeyCode.B);
+        this.targetElement.keyUp(KeyCode.B);
 
         expect(this.handler).to.not.have.been.called;
 
         this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+        this.targetElement.keyUp(KeyCode.A);
 
         expect(this.handler).to.have.been.calledOnce;
       });

--- a/test/HotKeys/focus-only/HandlersThatChangeFocus.spec.js
+++ b/test/HotKeys/focus-only/HandlersThatChangeFocus.spec.js
@@ -51,6 +51,7 @@ describe('Handlers that change focus:', function () {
       it('then focus is correctly managed', function() {
         this.firstElement.keyDown(KeyCode.A);
         this.firstElement.keyPress(KeyCode.A);
+        this.firstElement.keyUp(KeyCode.A);
 
         expect(this.nextHandler).to.have.been.calledOnce;
         expect(this.previousHandler).to.not.have.been.called;
@@ -59,6 +60,7 @@ describe('Handlers that change focus:', function () {
 
         this.firstElement.keyDown(KeyCode.B);
         this.firstElement.keyPress(KeyCode.B);
+        this.firstElement.keyUp(KeyCode.B);
 
         expect(this.nextHandler).to.have.been.calledOnce;
         expect(this.previousHandler).to.have.been.calledOnce;
@@ -67,5 +69,4 @@ describe('Handlers that change focus:', function () {
       });
     });
   });
-
 });

--- a/test/HotKeys/focus-only/MatchingHotKeyCombinations.spec.js
+++ b/test/HotKeys/focus-only/MatchingHotKeyCombinations.spec.js
@@ -6,184 +6,82 @@ import sinon from 'sinon';
 import FocusableElement from '../../support/FocusableElement';
 
 import KeyCode from '../../support/Key';
-import {HotKeys} from '../../../src/';
+import {HotKeys, configure} from '../../../src/';
 
 describe('Matching hotkey combinations:', function () {
-  describe('when the actions are triggered by the keydown event', function () {
-    beforeEach(function () {
-      this.keyMap = {
-        'COMBO1': { sequence: 'a+b', action: 'keydown' },
-        'COMBO2': { sequence: 'a+b+c', action: 'keydown' },
-      };
+  describe('when the allowCombinationSubmatches configuration option is set to false', () => {
+    describe('when the actions are triggered by the keydown event', function () {
+      beforeEach(function () {
+        this.keyMap = {
+          'COMBO1': { sequence: 'a+b', action: 'keydown' },
+          'COMBO2': { sequence: 'a+b+c', action: 'keydown' },
+        };
 
-      this.comboHandler = sinon.spy();
-      this.longerCombinationHandler = sinon.spy();
+        this.comboHandler = sinon.spy();
+        this.longerCombinationHandler = sinon.spy();
 
-      const handlers = {
-        'COMBO1': this.comboHandler,
-        'COMBO2': this.longerCombinationHandler,
-      };
+        const handlers = {
+          'COMBO1': this.comboHandler,
+          'COMBO2': this.longerCombinationHandler,
+        };
 
-      this.wrapper = mount(
-        <div >
-          <HotKeys keyMap={this.keyMap} handlers={handlers}>
-            <div className="childElement" />
-          </HotKeys>
+        this.wrapper = mount(
+          <div >
+            <HotKeys keyMap={this.keyMap} handlers={handlers}>
+              <div className="childElement" />
+            </HotKeys>
 
-          <div className="siblingElement" />
-        </div>
-      );
+            <div className="siblingElement" />
+          </div>
+        );
 
-      this.targetElement = new FocusableElement(this.wrapper, '.childElement');
-      this.targetElement.focus();
-    });
-
-    describe('and the first key is pressed and held', function () {
-      describe('and the keydown event for the second key in the combination occurs', () => {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
-
-          this.targetElement.keyDown(KeyCode.B);
-        });
-
-        it('then calls the key combination\'s handler', function() {
-          expect(this.comboHandler).to.have.been.calledOnce;
-        });
+        this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+        this.targetElement.focus();
       });
 
-      describe('and the keypress event for the second key in the combination occurs', () => {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
-
-          this.targetElement.keyDown(KeyCode.B);
-          this.targetElement.keyPress(KeyCode.B);
-        });
-
-        it('then does NOT call the key combination\'s handler again', function() {
-          expect(this.comboHandler).to.have.been.calledOnce;
-        });
-      });
-
-      describe('and the keyup event for the second key in the combination occurs', () => {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
-
-          this.targetElement.keyDown(KeyCode.B);
-          this.targetElement.keyPress(KeyCode.B);
-          this.targetElement.keyUp(KeyCode.B);
-
-          this.targetElement.keyUp(KeyCode.A);
-        });
-
-        it('then does NOT call the key combination\'s handler again', function() {
-          expect(this.comboHandler).to.have.been.calledOnce;
-        });
-      });
-    });
-
-    describe('and there is a combination that is a subset of a longer one', () => {
-      describe('and the keys have been pressed to satisfy the shorter combination without releasing the keys', () => {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
-
-          this.targetElement.keyDown(KeyCode.B);
-          this.targetElement.keyPress(KeyCode.B);
-        });
-
-        it('then calls the shorter key combination\'s handler', function() {
-          expect(this.comboHandler).to.have.been.calledOnce;
-          expect(this.longerCombinationHandler).to.not.have.been.called;
-        });
-
-        describe('and the remaining keys to satisfy the longer combination are pressed', () => {
+      describe('and the first key is pressed and held', function () {
+        describe('and the keydown event for the second key in the combination occurs', () => {
           beforeEach(function () {
-            this.targetElement.keyDown(KeyCode.C);
-            this.targetElement.keyPress(KeyCode.C);
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
           });
 
-          it('then calls the longer key combination\'s handler', function() {
-            expect(this.longerCombinationHandler).to.have.been.calledOnce;
+          it('then calls the key combination\'s handler', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
           });
         });
-      });
-    });
-  });
 
-  describe('when the actions are triggered by the keypress event', function () {
-    beforeEach(function () {
-      this.keyMap = {
-        'COMBO1': { sequence: 'a+b', action: 'keypress' },
-        'COMBO2': { sequence: 'a+b+c', action: 'keypress' },
-      };
+        describe('and the keypress event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
 
-      this.comboHandler = sinon.spy();
-      this.longerCombinationHandler = sinon.spy();
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+          });
 
-      const handlers = {
-        'COMBO1': this.comboHandler,
-        'COMBO2': this.longerCombinationHandler,
-      };
-
-      this.wrapper = mount(
-        <div >
-          <HotKeys keyMap={this.keyMap} handlers={handlers}>
-            <div className="childElement" />
-          </HotKeys>
-
-          <div className="siblingElement" />
-        </div>
-      );
-
-      this.targetElement = new FocusableElement(this.wrapper, '.childElement');
-      this.targetElement.focus();
-    });
-
-    describe('and the first key is pressed and held', function () {
-      describe('and the keydown event for the second key in the combination occurs', () => {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
-
-          this.targetElement.keyDown(KeyCode.B);
+          it('then does NOT call the key combination\'s handler again', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
         });
 
-        it('then no handlers are called', function() {
-          expect(this.comboHandler).to.not.have.been.called;
-        });
-      });
+        describe('and the keyup event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
 
-      describe('and the keypress event for the second key in the combination occurs', () => {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+            this.targetElement.keyUp(KeyCode.B);
 
-          this.targetElement.keyDown(KeyCode.B);
-          this.targetElement.keyPress(KeyCode.B);
-        });
+            this.targetElement.keyUp(KeyCode.A);
+          });
 
-        it('then calls the key combination\'s handler', function() {
-          expect(this.comboHandler).to.have.been.calledOnce;
-        });
-      });
-
-      describe('and the keyup event for the second key in the combination occurs', () => {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
-
-          this.targetElement.keyDown(KeyCode.B);
-          this.targetElement.keyPress(KeyCode.B);
-          this.targetElement.keyUp(KeyCode.B);
-
-          this.targetElement.keyUp(KeyCode.A);
-        });
-
-        it('then does NOT call the key combination\'s handler again', function() {
-          expect(this.comboHandler).to.have.been.calledOnce;
+          it('then does NOT call the key combination\'s handler again', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
         });
       });
 
@@ -215,170 +113,12 @@ describe('Matching hotkey combinations:', function () {
         });
       });
     });
-  });
 
-  describe('when the actions are triggered by the keyup event', function () {
-    beforeEach(function () {
-      this.keyMap = {
-        'COMBO1': { sequence: 'a+b', action: 'keyup' },
-        'COMBO2': { sequence: 'a+b+c', action: 'keyup' },
-      };
-
-      this.comboHandler = sinon.spy();
-      this.longerCombinationHandler = sinon.spy();
-
-      const handlers = {
-        'COMBO1': this.comboHandler,
-        'COMBO2': this.longerCombinationHandler,
-      };
-
-      this.wrapper = mount(
-        <HotKeys keyMap={this.keyMap} handlers={handlers}>
-          <div className="childElement" />
-        </HotKeys>
-      );
-
-      this.targetElement = new FocusableElement(this.wrapper, '.childElement');
-      this.targetElement.focus();
-    });
-
-    describe('and the first key is pressed and held', function () {
-      describe('and the keydown event for the second key in the combination occurs', () => {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
-
-          this.targetElement.keyDown(KeyCode.B);
-        });
-
-        it('then no handlers are called', function() {
-          expect(this.comboHandler).to.not.have.been.called;
-        });
-      });
-
-      describe('and the keypress event for the second key in the combination occurs', () => {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
-
-          this.targetElement.keyDown(KeyCode.B);
-          this.targetElement.keyPress(KeyCode.B);
-        });
-
-        it('then no handlers are called', function() {
-          expect(this.comboHandler).to.not.have.been.called;
-        });
-      });
-
-      describe('and the keyup event for the second key in the combination occurs', () => {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
-
-          this.targetElement.keyDown(KeyCode.B);
-          this.targetElement.keyPress(KeyCode.B);
-          this.targetElement.keyUp(KeyCode.B);
-
-          this.targetElement.keyUp(KeyCode.A);
-        });
-
-        it('then calls the key combination\'s handler', function() {
-          expect(this.comboHandler).to.have.been.calledOnce;
-        });
-      });
-    });
-
-    describe('and there is a combination that is a subset of a longer one', () => {
-      describe('and the keys have been pressed to satisfy the shorter combination without releasing the keys', () => {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
-
-          this.targetElement.keyDown(KeyCode.B);
-          this.targetElement.keyPress(KeyCode.B);
-        });
-
-        it('then no handlers are called', function() {
-          expect(this.comboHandler).to.not.have.been.called;
-        });
-
-        describe('and the remaining keys to satisfy the longer combination are pressed', () => {
-          beforeEach(function () {
-            this.targetElement.keyDown(KeyCode.C);
-            this.targetElement.keyPress(KeyCode.C);
-          });
-
-          it('then no handlers are called', function() {
-            expect(this.comboHandler).to.not.have.been.called;
-          });
-
-          describe('and a key in both combinations is released', function () {
-            beforeEach(function () {
-              this.targetElement.keyUp(KeyCode.A);
-            });
-
-            it('then no handlers are called', function() {
-              expect(this.comboHandler).to.not.have.been.called;
-            });
-          });
-
-          describe('and all the keys in the shorter combination are released followed by the key only in the longer combination', function () {
-            beforeEach(function () {
-              this.targetElement.keyUp(KeyCode.A);
-              this.targetElement.keyUp(KeyCode.B);
-
-              this.targetElement.keyUp(KeyCode.C);
-            });
-
-            it('then calls the shorter combination\'s handler followed by the longer combination\'s handler', function() {
-              expect(this.comboHandler).to.have.been.calledOnce;
-              expect(this.longerCombinationHandler).to.have.been.calledOnce;
-
-              expect(this.comboHandler).to.have.been.calledBefore(this.longerCombinationHandler);
-            });
-          });
-
-          describe('and all the keys are released with the key only in the longer combination released first', function () {
-            beforeEach(function () {
-              this.targetElement.keyUp(KeyCode.C);
-
-              this.targetElement.keyUp(KeyCode.A);
-              this.targetElement.keyUp(KeyCode.B);
-            });
-
-            it('then calls the longer combination\'s handler only', function() {
-              expect(this.comboHandler).to.not.have.been.called;
-              expect(this.longerCombinationHandler).to.have.been.calledOnce;
-            });
-          });
-
-          describe('and all the keys are released in an order that doesn\'t match the shorter combination', function () {
-            beforeEach(function () {
-              this.targetElement.keyUp(KeyCode.A);
-              this.targetElement.keyUp(KeyCode.C);
-              this.targetElement.keyUp(KeyCode.B);
-            });
-
-            it('then calls the longer combination\'s handler only', function() {
-              expect(this.comboHandler).to.not.have.been.called;
-              expect(this.longerCombinationHandler).to.have.been.calledOnce;
-            });
-          });
-        });
-      });
-    })
-  });
-
-  [
-    'keydown',
-    'keypress',
-    'keyup'
-  ].forEach((keyEvent) => {
-    describe(`when the actions are triggered by the ${keyEvent} event`, () => {
+    describe('when the actions are triggered by the keypress event', function () {
       beforeEach(function () {
         this.keyMap = {
-          'COMBO1': { sequence: 'a+b', action: keyEvent },
-          'COMBO2': { sequence: 'a+b+c', action: keyEvent },
+          'COMBO1': { sequence: 'a+b', action: 'keypress' },
+          'COMBO2': { sequence: 'a+b+c', action: 'keypress' },
         };
 
         this.comboHandler = sinon.spy();
@@ -403,108 +143,142 @@ describe('Matching hotkey combinations:', function () {
         this.targetElement.focus();
       });
 
-      describe('and NO key events have occurred', function () {
-        it('then no handlers are called', function() {
-          expect(this.comboHandler).to.not.have.been.called;
-        });
-      });
-
-      describe('and the first key in the combination is pressed and released', function () {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
-          this.targetElement.keyUp(KeyCode.A);
-        });
-
-        it('then no handlers are called', function() {
-          expect(this.comboHandler).to.not.have.been.called;
-        });
-      });
-
-      describe('and the second key in the combination is pressed after the first is released', function () {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
-          this.targetElement.keyUp(KeyCode.A);
-
-          this.targetElement.keyDown(KeyCode.B);
-          this.targetElement.keyPress(KeyCode.B);
-          this.targetElement.keyUp(KeyCode.B);
-        });
-
-        it('then no handlers are called', function() {
-          expect(this.comboHandler).to.not.have.been.called;
-        });
-      });
-
-      describe('and the keys involved in the combination are released in an order different to how they appear in the combination', () => {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.B);
-          this.targetElement.keyPress(KeyCode.B);
-
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
-
-          this.targetElement.keyUp(KeyCode.B);
-          this.targetElement.keyUp(KeyCode.A);
-        });
-
-        it('then calls the key combination\'s handler', function() {
-          expect(this.comboHandler).to.have.been.calledOnce;
-        });
-      });
-
-      describe('and the keys are released in an order different than when they are pressed', () => {
-        beforeEach(function () {
-          this.targetElement.keyDown(KeyCode.A);
-          this.targetElement.keyPress(KeyCode.A);
-
-          this.targetElement.keyDown(KeyCode.B);
-          this.targetElement.keyPress(KeyCode.B);
-
-          this.targetElement.keyUp(KeyCode.B);
-          this.targetElement.keyUp(KeyCode.A);
-        });
-
-        it('then calls the key combination\'s handler', function() {
-          expect(this.comboHandler).to.have.been.calledOnce;
-        });
-      });
-
-      describe('and the combination is used twice', () => {
-        beforeEach(function () {
-          for(let i = 0; i < 2; i++) {
-            this.targetElement.keyDown(KeyCode.A);
-            this.targetElement.keyPress(KeyCode.A);
-
-            this.targetElement.keyDown(KeyCode.B);
-            this.targetElement.keyPress(KeyCode.B);
-
-            this.targetElement.keyUp(KeyCode.B);
-            this.targetElement.keyUp(KeyCode.A);
-          }
-        });
-
-        it('then calls the key combination\'s handler twice', function() {
-          expect(this.comboHandler).to.have.been.calledTwice;
-        });
-      });
-
-      describe('and a key not in the combination is already held down', () => {
-
-        describe('and released afterwards', () => {
+      describe('and the first key is pressed and held', function () {
+        describe('and the keydown event for the second key in the combination occurs', () => {
           beforeEach(function () {
             this.targetElement.keyDown(KeyCode.A);
             this.targetElement.keyPress(KeyCode.A);
 
+            this.targetElement.keyDown(KeyCode.B);
+          });
+
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+        });
+
+        describe('and the keypress event for the second key in the combination occurs', () => {
+          beforeEach(function () {
             this.targetElement.keyDown(KeyCode.A);
             this.targetElement.keyPress(KeyCode.A);
 
             this.targetElement.keyDown(KeyCode.B);
             this.targetElement.keyPress(KeyCode.B);
+          });
 
+          it('then calls the key combination\'s handler', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
+        });
+
+        describe('and the keyup event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
             this.targetElement.keyUp(KeyCode.B);
+
             this.targetElement.keyUp(KeyCode.A);
+          });
+
+          it('then does NOT call the key combination\'s handler again', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
+        });
+
+        describe('and there is a combination that is a subset of a longer one', () => {
+          describe('and the keys have been pressed to satisfy the shorter combination without releasing the keys', () => {
+            beforeEach(function () {
+              this.targetElement.keyDown(KeyCode.A);
+              this.targetElement.keyPress(KeyCode.A);
+
+              this.targetElement.keyDown(KeyCode.B);
+              this.targetElement.keyPress(KeyCode.B);
+            });
+
+            it('then calls the shorter key combination\'s handler', function() {
+              expect(this.comboHandler).to.have.been.calledOnce;
+              expect(this.longerCombinationHandler).to.not.have.been.called;
+            });
+
+            describe('and the remaining keys to satisfy the longer combination are pressed', () => {
+              beforeEach(function () {
+                this.targetElement.keyDown(KeyCode.C);
+                this.targetElement.keyPress(KeyCode.C);
+              });
+
+              it('then calls the longer key combination\'s handler', function() {
+                expect(this.longerCombinationHandler).to.have.been.calledOnce;
+              });
+            });
+          });
+        });
+      });
+    });
+
+    describe('when the actions are triggered by the keyup event', function () {
+      beforeEach(function () {
+        this.keyMap = {
+          'COMBO1': { sequence: 'a+b', action: 'keyup' },
+          'COMBO2': { sequence: 'a+b+c', action: 'keyup' },
+        };
+
+        this.comboHandler = sinon.spy();
+        this.longerCombinationHandler = sinon.spy();
+
+        const handlers = {
+          'COMBO1': this.comboHandler,
+          'COMBO2': this.longerCombinationHandler,
+        };
+
+        this.wrapper = mount(
+          <HotKeys keyMap={this.keyMap} handlers={handlers}>
+            <div className="childElement" />
+          </HotKeys>
+        );
+
+        this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+        this.targetElement.focus();
+      });
+
+      describe('and the first key is pressed and held', function () {
+        describe('and the keydown event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+          });
+
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+        });
+
+        describe('and the keypress event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+          });
+
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+        });
+
+        describe('and the keyup event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+            this.targetElement.keyUp(KeyCode.B);
 
             this.targetElement.keyUp(KeyCode.A);
           });
@@ -513,15 +287,176 @@ describe('Matching hotkey combinations:', function () {
             expect(this.comboHandler).to.have.been.calledOnce;
           });
         });
+      });
 
-        describe('and released in the middle of the combination', () => {
+      describe('and there is a combination that is a subset of a longer one', () => {
+        describe('and the keys have been pressed to satisfy the shorter combination without releasing the keys', () => {
           beforeEach(function () {
-            this.targetElement.keyDown(KeyCode.ENTER);
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+          });
+
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+
+          describe('and the remaining keys to satisfy the longer combination are pressed', () => {
+            beforeEach(function () {
+              this.targetElement.keyDown(KeyCode.C);
+              this.targetElement.keyPress(KeyCode.C);
+            });
+
+            it('then no handlers are called', function() {
+              expect(this.comboHandler).to.not.have.been.called;
+            });
+
+            describe('and a key in both combinations is released', function () {
+              beforeEach(function () {
+                this.targetElement.keyUp(KeyCode.A);
+              });
+
+              it('then no handlers are called', function() {
+                expect(this.comboHandler).to.not.have.been.called;
+              });
+            });
+
+            describe('and all the keys in the shorter combination are released followed by the key only in the longer combination', function () {
+              beforeEach(function () {
+                this.targetElement.keyUp(KeyCode.A);
+                this.targetElement.keyUp(KeyCode.B);
+
+                this.targetElement.keyUp(KeyCode.C);
+              });
+
+              it('then only calls the longer combination\'s handler', function() {
+                expect(this.comboHandler).to.not.have.been.called;
+                expect(this.longerCombinationHandler).to.have.been.calledOnce;
+              });
+            });
+
+            describe('and all the keys are released with the key only in the longer combination released first', function () {
+              beforeEach(function () {
+                this.targetElement.keyUp(KeyCode.C);
+
+                this.targetElement.keyUp(KeyCode.A);
+                this.targetElement.keyUp(KeyCode.B);
+              });
+
+              it('then calls the longer combination\'s handler only', function() {
+                expect(this.comboHandler).to.not.have.been.called;
+                expect(this.longerCombinationHandler).to.have.been.calledOnce;
+              });
+            });
+
+            describe('and all the keys are released in an order that doesn\'t match the shorter combination', function () {
+              beforeEach(function () {
+                this.targetElement.keyUp(KeyCode.A);
+                this.targetElement.keyUp(KeyCode.C);
+                this.targetElement.keyUp(KeyCode.B);
+              });
+
+              it('then calls the longer combination\'s handler only', function() {
+                expect(this.comboHandler).to.not.have.been.called;
+                expect(this.longerCombinationHandler).to.have.been.calledOnce;
+              });
+            });
+          });
+        });
+      })
+    });
+
+    [
+      'keydown',
+      'keypress',
+      'keyup'
+    ].forEach((keyEvent) => {
+      describe(`when the actions are triggered by the ${keyEvent} event`, () => {
+        beforeEach(function () {
+          this.keyMap = {
+            'COMBO1': { sequence: 'a+b', action: keyEvent },
+            'COMBO2': { sequence: 'a+b+c', action: keyEvent },
+          };
+
+          this.comboHandler = sinon.spy();
+          this.longerCombinationHandler = sinon.spy();
+
+          const handlers = {
+            'COMBO1': this.comboHandler,
+            'COMBO2': this.longerCombinationHandler,
+          };
+
+          this.wrapper = mount(
+            <div >
+              <HotKeys keyMap={this.keyMap} handlers={handlers}>
+                <div className="childElement" />
+              </HotKeys>
+
+              <div className="siblingElement" />
+            </div>
+          );
+
+          this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+          this.targetElement.focus();
+        });
+
+        describe('and NO key events have occurred', function () {
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+        });
+
+        describe('and the first key in the combination is pressed and released', function () {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+            this.targetElement.keyUp(KeyCode.A);
+          });
+
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+        });
+
+        describe('and the second key in the combination is pressed after the first is released', function () {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+            this.targetElement.keyUp(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+            this.targetElement.keyUp(KeyCode.B);
+          });
+
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+        });
+
+        describe('and the keys involved in the combination are released in an order different to how they appear in the combination', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
 
             this.targetElement.keyDown(KeyCode.A);
             this.targetElement.keyPress(KeyCode.A);
 
-            this.targetElement.keyUp(KeyCode.ENTER);
+            this.targetElement.keyUp(KeyCode.B);
+            this.targetElement.keyUp(KeyCode.A);
+          });
+
+          it('then calls the key combination\'s handler', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
+        });
+
+        describe('and the keys are released in an order different than when they are pressed', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
 
             this.targetElement.keyDown(KeyCode.B);
             this.targetElement.keyPress(KeyCode.B);
@@ -534,8 +469,611 @@ describe('Matching hotkey combinations:', function () {
             expect(this.comboHandler).to.have.been.calledOnce;
           });
         });
-      });
-    })
+
+        describe('and the combination is used twice', () => {
+          beforeEach(function () {
+            for(let i = 0; i < 2; i++) {
+              this.targetElement.keyDown(KeyCode.A);
+              this.targetElement.keyPress(KeyCode.A);
+
+              this.targetElement.keyDown(KeyCode.B);
+              this.targetElement.keyPress(KeyCode.B);
+
+              this.targetElement.keyUp(KeyCode.B);
+              this.targetElement.keyUp(KeyCode.A);
+            }
+          });
+
+          it('then calls the key combination\'s handler twice', function() {
+            expect(this.comboHandler).to.have.been.calledTwice;
+          });
+        });
+
+        describe('and a key not in the combination is already held down', () => {
+
+          describe('and released afterwards', () => {
+            beforeEach(function () {
+              this.targetElement.keyDown(KeyCode.A);
+              this.targetElement.keyPress(KeyCode.A);
+
+              this.targetElement.keyDown(KeyCode.A);
+              this.targetElement.keyPress(KeyCode.A);
+
+              this.targetElement.keyDown(KeyCode.B);
+              this.targetElement.keyPress(KeyCode.B);
+
+              this.targetElement.keyUp(KeyCode.B);
+              this.targetElement.keyUp(KeyCode.A);
+
+              this.targetElement.keyUp(KeyCode.A);
+            });
+
+            it('then calls the key combination\'s handler', function() {
+              expect(this.comboHandler).to.have.been.calledOnce;
+            });
+          });
+
+          describe('and released in the middle of the combination', () => {
+            beforeEach(function () {
+              this.targetElement.keyDown(KeyCode.ENTER);
+
+              this.targetElement.keyDown(KeyCode.A);
+              this.targetElement.keyPress(KeyCode.A);
+
+              this.targetElement.keyUp(KeyCode.ENTER);
+
+              this.targetElement.keyDown(KeyCode.B);
+              this.targetElement.keyPress(KeyCode.B);
+
+              this.targetElement.keyUp(KeyCode.B);
+              this.targetElement.keyUp(KeyCode.A);
+            });
+
+            it('then calls the key combination\'s handler', function() {
+              expect(this.comboHandler).to.have.been.calledOnce;
+            });
+          });
+        });
+      })
+    });
   });
 
+  describe('when the allowCombinationSubmatches configuration option is set to true', () => {
+    before(function(){
+      configure({allowCombinationSubmatches: true });
+    });
+
+    after(function() {
+      configure({allowCombinationSubmatches: false });
+    });
+
+    describe('when the actions are triggered by the keydown event', function () {
+      beforeEach(function () {
+        this.keyMap = {
+          'COMBO1': { sequence: 'a+b', action: 'keydown' },
+          'COMBO2': { sequence: 'a+b+c', action: 'keydown' },
+        };
+
+        this.comboHandler = sinon.spy();
+        this.longerCombinationHandler = sinon.spy();
+
+        const handlers = {
+          'COMBO1': this.comboHandler,
+          'COMBO2': this.longerCombinationHandler,
+        };
+
+        this.wrapper = mount(
+          <div >
+            <HotKeys keyMap={this.keyMap} handlers={handlers}>
+              <div className="childElement" />
+            </HotKeys>
+
+            <div className="siblingElement" />
+          </div>
+        );
+
+        this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+        this.targetElement.focus();
+      });
+
+      describe('and the first key is pressed and held', function () {
+        describe('and the keydown event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+          });
+
+          it('then calls the key combination\'s handler', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
+        });
+
+        describe('and the keypress event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+          });
+
+          it('then does NOT call the key combination\'s handler again', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
+        });
+
+        describe('and the keyup event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+            this.targetElement.keyUp(KeyCode.B);
+
+            this.targetElement.keyUp(KeyCode.A);
+          });
+
+          it('then does NOT call the key combination\'s handler again', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
+        });
+      });
+
+      describe('and there is a combination that is a subset of a longer one', () => {
+        describe('and the keys have been pressed to satisfy the shorter combination without releasing the keys', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+          });
+
+          it('then calls the shorter key combination\'s handler', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+            expect(this.longerCombinationHandler).to.not.have.been.called;
+          });
+
+          describe('and the remaining keys to satisfy the longer combination are pressed', () => {
+            beforeEach(function () {
+              this.targetElement.keyDown(KeyCode.C);
+              this.targetElement.keyPress(KeyCode.C);
+            });
+
+            it('then calls the longer key combination\'s handler', function() {
+              expect(this.longerCombinationHandler).to.have.been.calledOnce;
+            });
+          });
+        });
+      });
+    });
+
+    describe('when the actions are triggered by the keypress event', function () {
+      beforeEach(function () {
+        this.keyMap = {
+          'COMBO1': { sequence: 'a+b', action: 'keypress' },
+          'COMBO2': { sequence: 'a+b+c', action: 'keypress' },
+        };
+
+        this.comboHandler = sinon.spy();
+        this.longerCombinationHandler = sinon.spy();
+
+        const handlers = {
+          'COMBO1': this.comboHandler,
+          'COMBO2': this.longerCombinationHandler,
+        };
+
+        this.wrapper = mount(
+          <div >
+            <HotKeys keyMap={this.keyMap} handlers={handlers}>
+              <div className="childElement" />
+            </HotKeys>
+
+            <div className="siblingElement" />
+          </div>
+        );
+
+        this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+        this.targetElement.focus();
+      });
+
+      describe('and the first key is pressed and held', function () {
+        describe('and the keydown event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+          });
+
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+        });
+
+        describe('and the keypress event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+          });
+
+          it('then calls the key combination\'s handler', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
+        });
+
+        describe('and the keyup event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+            this.targetElement.keyUp(KeyCode.B);
+
+            this.targetElement.keyUp(KeyCode.A);
+          });
+
+          it('then does NOT call the key combination\'s handler again', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
+        });
+
+        describe('and there is a combination that is a subset of a longer one', () => {
+          describe('and the keys have been pressed to satisfy the shorter combination without releasing the keys', () => {
+            beforeEach(function () {
+              this.targetElement.keyDown(KeyCode.A);
+              this.targetElement.keyPress(KeyCode.A);
+
+              this.targetElement.keyDown(KeyCode.B);
+              this.targetElement.keyPress(KeyCode.B);
+            });
+
+            it('then calls the shorter key combination\'s handler', function() {
+              expect(this.comboHandler).to.have.been.calledOnce;
+              expect(this.longerCombinationHandler).to.not.have.been.called;
+            });
+
+            describe('and the remaining keys to satisfy the longer combination are pressed', () => {
+              beforeEach(function () {
+                this.targetElement.keyDown(KeyCode.C);
+                this.targetElement.keyPress(KeyCode.C);
+              });
+
+              it('then calls the longer key combination\'s handler', function() {
+                expect(this.longerCombinationHandler).to.have.been.calledOnce;
+              });
+            });
+          });
+        });
+      });
+    });
+
+    describe('when the actions are triggered by the keyup event', function () {
+      beforeEach(function () {
+        this.keyMap = {
+          'COMBO1': { sequence: 'a+b', action: 'keyup' },
+          'COMBO2': { sequence: 'a+b+c', action: 'keyup' },
+        };
+
+        this.comboHandler = sinon.spy();
+        this.longerCombinationHandler = sinon.spy();
+
+        const handlers = {
+          'COMBO1': this.comboHandler,
+          'COMBO2': this.longerCombinationHandler,
+        };
+
+        this.wrapper = mount(
+          <HotKeys keyMap={this.keyMap} handlers={handlers}>
+            <div className="childElement" />
+          </HotKeys>
+        );
+
+        this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+        this.targetElement.focus();
+      });
+
+      describe('and the first key is pressed and held', function () {
+        describe('and the keydown event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+          });
+
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+        });
+
+        describe('and the keypress event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+          });
+
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+        });
+
+        describe('and the keyup event for the second key in the combination occurs', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+            this.targetElement.keyUp(KeyCode.B);
+
+            this.targetElement.keyUp(KeyCode.A);
+          });
+
+          it('then calls the key combination\'s handler', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
+        });
+      });
+
+      describe('and there is a combination that is a subset of a longer one', () => {
+        describe('and the keys have been pressed to satisfy the shorter combination without releasing the keys', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+          });
+
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+
+          describe('and the remaining keys to satisfy the longer combination are pressed', () => {
+            beforeEach(function () {
+              this.targetElement.keyDown(KeyCode.C);
+              this.targetElement.keyPress(KeyCode.C);
+            });
+
+            it('then no handlers are called', function() {
+              expect(this.comboHandler).to.not.have.been.called;
+            });
+
+            describe('and a key in both combinations is released', function () {
+              beforeEach(function () {
+                this.targetElement.keyUp(KeyCode.A);
+              });
+
+              it('then no handlers are called', function() {
+                expect(this.comboHandler).to.not.have.been.called;
+              });
+            });
+
+            describe('and all the keys in the shorter combination are released followed by the key only in the longer combination', function () {
+              beforeEach(function () {
+                this.targetElement.keyUp(KeyCode.A);
+                this.targetElement.keyUp(KeyCode.B);
+
+                this.targetElement.keyUp(KeyCode.C);
+              });
+
+              it('then calls the shorter combination\'s handler followed by the longer combination\'s handler', function() {
+                expect(this.comboHandler).to.have.been.calledOnce;
+                expect(this.longerCombinationHandler).to.have.been.calledOnce;
+
+                expect(this.comboHandler).to.have.been.calledBefore(this.longerCombinationHandler);
+              });
+            });
+
+            describe('and all the keys are released with the key only in the longer combination released first', function () {
+              beforeEach(function () {
+                this.targetElement.keyUp(KeyCode.C);
+
+                this.targetElement.keyUp(KeyCode.A);
+                this.targetElement.keyUp(KeyCode.B);
+              });
+
+              it('then calls the longer combination\'s handler only', function() {
+                expect(this.comboHandler).to.not.have.been.called;
+                expect(this.longerCombinationHandler).to.have.been.calledOnce;
+              });
+            });
+
+            describe('and all the keys are released in an order that doesn\'t match the shorter combination', function () {
+              beforeEach(function () {
+                this.targetElement.keyUp(KeyCode.A);
+                this.targetElement.keyUp(KeyCode.C);
+                this.targetElement.keyUp(KeyCode.B);
+              });
+
+              it('then calls the longer combination\'s handler only', function() {
+                expect(this.comboHandler).to.not.have.been.called;
+                expect(this.longerCombinationHandler).to.have.been.calledOnce;
+              });
+            });
+          });
+        });
+      })
+    });
+
+    [
+      'keydown',
+      'keypress',
+      'keyup'
+    ].forEach((keyEvent) => {
+      describe(`when the actions are triggered by the ${keyEvent} event`, () => {
+        beforeEach(function () {
+          this.keyMap = {
+            'COMBO1': { sequence: 'a+b', action: keyEvent },
+            'COMBO2': { sequence: 'a+b+c', action: keyEvent },
+          };
+
+          this.comboHandler = sinon.spy();
+          this.longerCombinationHandler = sinon.spy();
+
+          const handlers = {
+            'COMBO1': this.comboHandler,
+            'COMBO2': this.longerCombinationHandler,
+          };
+
+          this.wrapper = mount(
+            <div >
+              <HotKeys keyMap={this.keyMap} handlers={handlers}>
+                <div className="childElement" />
+              </HotKeys>
+
+              <div className="siblingElement" />
+            </div>
+          );
+
+          this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+          this.targetElement.focus();
+        });
+
+        describe('and NO key events have occurred', function () {
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+        });
+
+        describe('and the first key in the combination is pressed and released', function () {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+            this.targetElement.keyUp(KeyCode.A);
+          });
+
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+        });
+
+        describe('and the second key in the combination is pressed after the first is released', function () {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+            this.targetElement.keyUp(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+            this.targetElement.keyUp(KeyCode.B);
+          });
+
+          it('then no handlers are called', function() {
+            expect(this.comboHandler).to.not.have.been.called;
+          });
+        });
+
+        describe('and the keys involved in the combination are released in an order different to how they appear in the combination', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyUp(KeyCode.B);
+            this.targetElement.keyUp(KeyCode.A);
+          });
+
+          it('then calls the key combination\'s handler', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
+        });
+
+        describe('and the keys are released in an order different than when they are pressed', () => {
+          beforeEach(function () {
+            this.targetElement.keyDown(KeyCode.A);
+            this.targetElement.keyPress(KeyCode.A);
+
+            this.targetElement.keyDown(KeyCode.B);
+            this.targetElement.keyPress(KeyCode.B);
+
+            this.targetElement.keyUp(KeyCode.B);
+            this.targetElement.keyUp(KeyCode.A);
+          });
+
+          it('then calls the key combination\'s handler', function() {
+            expect(this.comboHandler).to.have.been.calledOnce;
+          });
+        });
+
+        describe('and the combination is used twice', () => {
+          beforeEach(function () {
+            for(let i = 0; i < 2; i++) {
+              this.targetElement.keyDown(KeyCode.A);
+              this.targetElement.keyPress(KeyCode.A);
+
+              this.targetElement.keyDown(KeyCode.B);
+              this.targetElement.keyPress(KeyCode.B);
+
+              this.targetElement.keyUp(KeyCode.B);
+              this.targetElement.keyUp(KeyCode.A);
+            }
+          });
+
+          it('then calls the key combination\'s handler twice', function() {
+            expect(this.comboHandler).to.have.been.calledTwice;
+          });
+        });
+
+        describe('and a key not in the combination is already held down', () => {
+
+          describe('and released afterwards', () => {
+            beforeEach(function () {
+              this.targetElement.keyDown(KeyCode.A);
+              this.targetElement.keyPress(KeyCode.A);
+
+              this.targetElement.keyDown(KeyCode.A);
+              this.targetElement.keyPress(KeyCode.A);
+
+              this.targetElement.keyDown(KeyCode.B);
+              this.targetElement.keyPress(KeyCode.B);
+
+              this.targetElement.keyUp(KeyCode.B);
+              this.targetElement.keyUp(KeyCode.A);
+
+              this.targetElement.keyUp(KeyCode.A);
+            });
+
+            it('then calls the key combination\'s handler', function() {
+              expect(this.comboHandler).to.have.been.calledOnce;
+            });
+          });
+
+          describe('and released in the middle of the combination', () => {
+            beforeEach(function () {
+              this.targetElement.keyDown(KeyCode.ENTER);
+
+              this.targetElement.keyDown(KeyCode.A);
+              this.targetElement.keyPress(KeyCode.A);
+
+              this.targetElement.keyUp(KeyCode.ENTER);
+
+              this.targetElement.keyDown(KeyCode.B);
+              this.targetElement.keyPress(KeyCode.B);
+
+              this.targetElement.keyUp(KeyCode.B);
+              this.targetElement.keyUp(KeyCode.A);
+            });
+
+            it('then calls the key combination\'s handler', function() {
+              expect(this.comboHandler).to.have.been.calledOnce;
+            });
+          });
+        });
+      })
+    });
+  });
 });


### PR DESCRIPTION
# Context

The current action matching behaviour of `react-hotkeys` has caused confusion and seemed to contradict user's expectations a couple of times  (#161, #181, #175): It first examines `<HotKeys/>` components closest to the element currently in focus, and then moves towards the top of the app, examining the full hierarchy of focused `<HotKeys />` components, before moving on to `<GlobalHotkeys/>`. 

The trouble is that submatches are allowed in this matching process: If an application has a context-dependent action, bound to a short key combination (e.g. `?`) and a longer global action bound to a longer key combination (e.g. `shift+?`) the longer key combination is hidden behind the shorter one and never triggered whenever a child of the `<HotKeys/>` component that defines the shorter combination is in focus.

# This pull request

* Adds a new `allowCombinationSubmatches` configuration option to enable submatching and disables it by default (i.e. submatching is turned off by default)
* Moves around some Readme sections and adds a more in depth description of how the key matching algorithm works, together with its customisation options and the tradeoffs.
* Updates the test suite to cover the new expected behaviour for both configuration option settings.