### PR TITLE
🐛 Fix #187: Add root prop to HotKeys to allow root HotKeys components…

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ export default MyNode;
     - [Other keyboard event listeners are no longer being triggered](#other-keyboard-event-listeners-are-no-longer-being-triggered)
     - [Actions aren't being triggered when using withHotKeys](#actions-arent-being-triggered-when-using-withhotkeys)
     - [Actions aren't being triggered for HotKeys](#actions-arent-being-triggered-for-hotkeys)
+    - [React Hotkeys thinks I'm holding down a key I've released](#react-hotkeys-thinks-im-holding-down-a-key-ive-released)
     - [Blue border appears around children of HotKeys](#blue-border-appears-around-children-of-hotkeys)
 - [Stability & Maintenance](#stability--maintenance)
 - [Contribute, please!](#contribute-please)
@@ -453,6 +454,12 @@ However, it [does require that its children be wrapped in a DOM-mounted node](#H
    * to get a reference to the node, so you can call .focus() on it
    */
   innerRef: {undefined}
+  
+  /**
+   * Whether this is the root HotKeys node - this enables some special 
+   * behaviour
+   */
+  root={false}
   >
 
   /**
@@ -1219,6 +1226,16 @@ Check that the `<HotKeys>` component that defines the handler is also an ancesto
 Also make sure your React application is not calling `stopPropagation()` on the key events before they reach the `<HotKeys>` component that defines the `keyMap`.
 
 Finally, make sure your key event are not coming from one of the [tags ignored by react-hotkeys](#Ignoring-events).
+
+#### React Hotkeys thinks I'm holding down a key I've released
+
+This can happen when you have an action handler that either unmounts the `<HotKeys>` component, or focuses an area of the application where there is no parent `<HotKeys>`. The solution to this is to add a `<HotKeys root>` to the top of your application that renders it as children - or at least high enough to *not* be unmounted or unfocused by your action handler.
+
+```javascript
+<HotKeys root>
+  // The parts of your application that are re-rendered or unfocused here
+</HotKeys>
+```
 
 #### Blue border appears around children of HotKeys
 

--- a/README.md
+++ b/README.md
@@ -1229,7 +1229,7 @@ Finally, make sure your key event are not coming from one of the [tags ignored b
 
 #### React Hotkeys thinks I'm holding down a key I've released
 
-This can happen when you have an action handler that either unmounts the `<HotKeys>` component, or focuses an area of the application where there is no parent `<HotKeys>`. The solution to this is to add a `<HotKeys root>` to the top of your application that renders it as children - or at least high enough to *not* be unmounted or unfocused by your action handler.
+This can happen when you have an action handler that either unmounts the `<HotKeys>` component, or focuses an area of the application where there is no ancestor `<HotKeys>`. The solution is to add a `<HotKeys>` component with the `root` prop to the top of your application - or at least high enough to *not* be unmounted or unfocused by your action handler.
 
 ```javascript
 <HotKeys root>

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,6 +53,11 @@ export interface HotKeysEnabledProps extends GlobalHotKeysProps {
    * Function to call when this component loses focus in the browser
    */
   onBlur?: () => void;
+
+  /**
+   * Whether this is the root HotKeys node - this enables some special behaviour
+   */
+  root?: boolean;
 }
 
 /**

--- a/src/withHotKeys.js
+++ b/src/withHotKeys.js
@@ -113,7 +113,12 @@ function withHotKeys(Component, hotKeysOptions = {}) {
        * component mounts. If false, changes to the keyMap and handlers
        * props will be ignored
        */
-      allowChanges: PropTypes.bool
+      allowChanges: PropTypes.bool,
+
+      /**
+       * Whether this is the root HotKeys node - this enables some special behaviour
+       */
+      root: PropTypes.bool
     };
 
     constructor(props) {
@@ -152,7 +157,7 @@ function withHotKeys(Component, hotKeysOptions = {}) {
          * Props used by HotKeys that should not be passed down to its focus trap
          * component
          */
-        keyMap, handlers, allowChanges,
+        keyMap, handlers, allowChanges, root,
 
         ...props
       } = this.props;
@@ -181,7 +186,7 @@ function withHotKeys(Component, hotKeysOptions = {}) {
     _shouldBindKeyListeners() {
       const keyMap = getKeyMap(this.props);
 
-      return !isEmpty(keyMap) || (
+      return !isEmpty(keyMap) || this.props.root || (
         Configuration.option('enableHardSequences') && this._handlersIncludeHardSequences(keyMap, getHandlers(this.props))
       );
     }

--- a/test/HotKeys/focus-only/RootProp.spec.js
+++ b/test/HotKeys/focus-only/RootProp.spec.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {expect} from 'chai';
+import sinon from 'sinon';
+
+import FocusableElement from '../../support/FocusableElement';
+import KeyEventManager from '../../../src/lib/KeyEventManager';
+import KeyCode from '../../support/Key';
+
+import {HotKeys} from '../../../src/';
+
+describe('HotKeys root prop:', function () {
+  describe('when a HotKeys component has a root prop value of true', function () {
+    beforeEach(function () {
+      this.keyMap = {
+        'NEXT': 'a',
+      };
+
+      this.nextHandler = sinon.spy();
+
+      const handlers = {
+        'NEXT': () => {
+          this.secondElement.focus();
+
+          this.nextHandler();
+        }
+      };
+
+      this.wrapper = mount(
+        <HotKeys root>
+          <HotKeys keyMap={this.keyMap} handlers={handlers}>
+            <div className='firstChildElement' />
+          </HotKeys>
+
+          <div className='secondChildElement' />
+        </HotKeys>
+      );
+
+      this.firstElement = new FocusableElement(this.wrapper, '.firstChildElement');
+      this.secondElement = new FocusableElement(this.wrapper, '.secondChildElement');
+
+      this.firstElement.focus();
+
+      expect(this.firstElement.isFocused()).to.equal(true);
+    });
+
+    describe('and nested HotKeys component has a handler that changes focus to another element bound to keydown', function () {
+      it('then the root HotKeys still records the keyup event', function() {
+        this.firstElement.keyDown(KeyCode.A);
+
+        expect(this.nextHandler).to.have.been.calledOnce;
+
+        expect(this.secondElement.isFocused()).to.equal(true);
+
+        this.secondElement.keyPress(KeyCode.A);
+        this.secondElement.keyUp(KeyCode.A);
+
+        expect(KeyEventManager.getInstance()._focusOnlyEventStrategy.keyCombinationHistory).to.eql([
+          {
+            'keys': {
+              'a': [
+                [true, true, false],
+                [true, true, true]
+              ]
+            },
+            'ids': ['a'],
+            'keyAliases': {}
+          }
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Context

A recent pull request (#186) switched from observing key combination submatches, to ignoring them by default. This revealed there is an issue (#187) with key events being missed by React HotKeys in circumstances where an action is defined with a handler that changes the React DOM or focused element in such a way that the new focused element is outside of any `<HotKeys />` descendants, resulting in the corresponding `keyup` event never being logged - and `react-hotkeys` behaving as if the key is still held down.

A simple fix for this, is to place a `<HotKeys />` component at the top of the react application, so no matter what new content is rendered or what element is focused, it would still be within the descendants of a `<HotKeys />` component. However, one `react-hotkeys`' optimisations is that unless a `<HotKeys />` component defines a `keyMap` prop, it's not actually added to the list of components listening out for key events. This means a user would have to define a `keyMap` prop of some value (say an empty object), just to get the desired behaviour.

# This pull request

Adds a `root` prop to the `<HotKeys />` component, so a user can add such a root `<HotKeys />` component, without resorting to a hack to circumvent the intended optimisations in place.