### PR TITLE
Dev closing hanging combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1237,6 +1237,8 @@ This can happen when you have an action handler that either unmounts the `<HotKe
 </HotKeys>
 ```
 
+Alternatively, you can add a `<GlobalHotKeys/>` component anywhere in your application and it will close key combinations left hanging by your `<HotKeys />` components due to missed `keypress` and `keyup` events.
+
 #### Blue border appears around children of HotKeys
 
 `react-hotkeys` adds a `<div />` around its children with a `tabindex="-1"` to allow them to be programmatically focused. This can result in browsers rendering a blue outline around them to visually indicate that they are the elements in the document that is currently in focus.

--- a/src/helpers/parsing-key-maps/keyIsCurrentlyTriggeringEvent.js
+++ b/src/helpers/parsing-key-maps/keyIsCurrentlyTriggeringEvent.js
@@ -1,0 +1,15 @@
+import KeyEventSequenceIndex from '../../const/KeyEventSequenceIndex';
+
+/**
+ * Whether the a key is in a particular state. i.e. whether the specified key state
+ * currently has the bit at eventBitmapIndex set to true.
+ * @param {KeyCombinationRecord} keyState The key state to examine
+ * @param {KeyEventBitmapIndex} eventBitmapIndex The index of the bit to examine
+ * @returns {Boolean} True when the bit at the eventBitmapIndex is currently flipped
+ *        or set to true
+ */
+function keyIsCurrentlyTriggeringEvent(keyState, eventBitmapIndex) {
+  return keyState && keyState[KeyEventSequenceIndex.current][eventBitmapIndex];
+}
+
+export default keyIsCurrentlyTriggeringEvent;

--- a/src/lib/KeyEventManager.js
+++ b/src/lib/KeyEventManager.js
@@ -411,6 +411,18 @@ class KeyEventManager {
     this._focusOnlyEventStrategy.forceObserveEvent(event);
   }
 
+  /**
+   * Closes any hanging key combinations that have not received the key event indicated
+   * by bitmapIndex.
+   * @param {KeyName} keyName The name of the key whose state should be updated if it
+   *        is currently set to keydown or keypress.
+   * @param {KeyEventBitmapIndex} bitmapIndex Index of key event to move the key state
+   *        up to.
+   */
+  closeHangingKeyCombination(keyName, bitmapIndex) {
+    this._focusOnlyEventStrategy.closeHangingKeyCombination(keyName, bitmapIndex);
+  }
+
   reactAppHistoryWithEvent(key, type) {
     const { currentEvent } = this._focusOnlyEventStrategy;
 

--- a/src/lib/strategies/AbstractKeyEventStrategy.js
+++ b/src/lib/strategies/AbstractKeyEventStrategy.js
@@ -22,6 +22,7 @@ import Configuration from '../Configuration';
 import ModifierFlagsDictionary from '../../const/ModifierFlagsDictionary';
 import without from '../../utils/collection/without';
 import hasKeyPressEvent from '../../helpers/resolving-handlers/hasKeyPressEvent';
+import keyIsCurrentlyTriggeringEvent from '../../helpers/parsing-key-maps/keyIsCurrentlyTriggeringEvent';
 import isMatchPossibleBasedOnNumberOfKeys from '../../helpers/resolving-handlers/isMatchPossibleBasedOnNumberOfKeys';
 
 /**
@@ -1233,10 +1234,6 @@ class AbstractKeyEventStrategy {
   _logPrefix() {
 
   }
-}
-
-function keyIsCurrentlyTriggeringEvent(keyState, eventBitmapIndex) {
-  return keyState && keyState[KeyEventSequenceIndex.current][eventBitmapIndex];
 }
 
 function getKeyAlias(keyCombination, keyName) {

--- a/src/lib/strategies/GlobalKeyEventStrategy.js
+++ b/src/lib/strategies/GlobalKeyEventStrategy.js
@@ -202,7 +202,7 @@ class GlobalKeyEventStrategy extends AbstractKeyEventStrategy {
   }
 
   _updateDocumentHandlers(){
-    const listenersShouldBeBound = this.keyMapEventBitmap.some((eventType) => eventType);
+    const listenersShouldBeBound = this.componentList.length > 0;
 
     if (!this.listenersBound && listenersShouldBeBound) {
       for(let bitmapIndex = 0; bitmapIndex < this.keyMapEventBitmap.length; bitmapIndex++) {

--- a/test/GlobalHotKeys/ClosingHangingCombinationsInHotKeysComponents.spec.js
+++ b/test/GlobalHotKeys/ClosingHangingCombinationsInHotKeysComponents.spec.js
@@ -8,10 +8,10 @@ import FocusableElement from '../support/FocusableElement';
 import KeyEventManager from '../../src/lib/KeyEventManager';
 import KeyCode from '../support/Key';
 
-import {HotKeys, GlobalHotKeys, configure} from '../../src';
+import {HotKeys, GlobalHotKeys} from '../../src';
 
-describe('HotKeys root prop:', function () {
-  describe('when a HotKeys component has a root prop value of true', function () {
+describe('ClosingHangingCombinationsInHotKeysComponents:', function () {
+  describe('when a HotKeys component has a handler on keydown that changes the focus to outside its descendants', function () {
     beforeEach(function () {
       this.keyMap = {
         'NEXT': 'a',
@@ -55,8 +55,8 @@ describe('HotKeys root prop:', function () {
       document.body.removeChild(this.reactDiv);
     });
 
-    describe('and nested HotKeys component has a handler that changes focus to another element bound to keydown', function () {
-      it('then the root HotKeys still records the keyup event', function() {
+    describe('and there is a GlobalHotKeys component also mounted', function () {
+      it('then the GlobalHotKeys component will close the hanging combination by reporting the missed keypress and keyup events to the HotKeys component', function() {
         this.firstElement.keyDown(KeyCode.A);
 
         expect(this.nextHandler).to.have.been.calledOnce;

--- a/test/GlobalHotKeys/ClosingKeyCombinationsStartedInHotKeys.spec.js
+++ b/test/GlobalHotKeys/ClosingKeyCombinationsStartedInHotKeys.spec.js
@@ -32,7 +32,7 @@ describe('HotKeys root prop:', function () {
 
       this.wrapper = mount(
         <div>
-          <GlobalHotKeys keyMap={this.keyMap} handlers={handlers} />
+          <GlobalHotKeys />
 
           <HotKeys keyMap={this.keyMap} handlers={handlers}>
             <div className='firstChildElement' />

--- a/test/GlobalHotKeys/ClosingKeyCombinationsStartedInHotKeys.spec.js
+++ b/test/GlobalHotKeys/ClosingKeyCombinationsStartedInHotKeys.spec.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import {mount} from 'enzyme/build';
+import {expect} from 'chai';
+import sinon from 'sinon';
+import simulant from 'simulant';
+
+import FocusableElement from '../support/FocusableElement';
+import KeyEventManager from '../../src/lib/KeyEventManager';
+import KeyCode from '../support/Key';
+
+import {HotKeys, GlobalHotKeys, configure} from '../../src';
+
+describe('HotKeys root prop:', function () {
+  describe('when a HotKeys component has a root prop value of true', function () {
+    beforeEach(function () {
+      this.keyMap = {
+        'NEXT': 'a',
+      };
+
+      this.nextHandler = sinon.spy();
+
+      const handlers = {
+        'NEXT': () => {
+          this.secondElement.focus();
+
+          this.nextHandler();
+        }
+      };
+
+      this.reactDiv = document.createElement('div');
+      document.body.appendChild(this.reactDiv);
+
+      this.wrapper = mount(
+        <div>
+          <GlobalHotKeys keyMap={this.keyMap} handlers={handlers} />
+
+          <HotKeys keyMap={this.keyMap} handlers={handlers}>
+            <div className='firstChildElement' />
+          </HotKeys>
+
+          <div className='secondChildElement' />
+        </div>,
+        { attachTo: this.reactDiv }
+      );
+
+      this.firstElement = new FocusableElement(this.wrapper, '.firstChildElement');
+      this.secondElement = new FocusableElement(this.wrapper, '.secondChildElement');
+
+      this.firstElement.focus();
+
+      expect(this.firstElement.isFocused()).to.equal(true);
+    });
+
+    afterEach(function() {
+      document.body.removeChild(this.reactDiv);
+    });
+
+    describe('and nested HotKeys component has a handler that changes focus to another element bound to keydown', function () {
+      it('then the root HotKeys still records the keyup event', function() {
+        this.firstElement.keyDown(KeyCode.A);
+
+        expect(this.nextHandler).to.have.been.calledOnce;
+
+        expect(this.secondElement.isFocused()).to.equal(true);
+
+        simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+        simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+
+        expect(KeyEventManager.getInstance()._focusOnlyEventStrategy.keyCombinationHistory).to.eql([
+          {
+            'keys': {
+              'a': [
+                [true, true, false],
+                [true, true, true]
+              ]
+            },
+            'ids': ['a'],
+            'keyAliases': {}
+          }
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Context

A recent pull request (#186) switched from observing key combination submatches, to ignoring them by default. This revealed there is an issue (#187) with key events being missed by React HotKeys in circumstances where an action is defined with a handler that changes the React DOM or focused element in such a way that the new focused element is outside of any <HotKeys /> descendants, resulting in the corresponding keyup event never being logged - and react-hotkeys behaving as if the key is still held down.

One possible (partial) solution to this problem was the addition of a `root` prop for `HotKeys` components (#187). This has its advantages of not requiring binding to the document, and remaining relatively self-contained. However, it's limited in its scope and not all users can or want to place a `HotKeys` component towards the root of their application.

# This pull request

Allows `GlobalHotKeys` components to report any missed key events to `HotKeys`, and to close any hanging key combinations that arise because an action handler changes focus outside of the `HotKeys` component before it can register the `keypress` or `keyup` event.