### PR TITLE
🌟 #154: Add ability to specify name, group and description to keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,15 +682,13 @@ A more exhaustive enumeration of `react-hotkeys` behaviour can be found by revie
 
 They are returned as an object, with the action names as keys, and the values are objects describing the key map.
 
-Regardless of which syntax you used to define the keymap, they always appear in the following syntax:
+Regardless of which syntax you used to define the keymap, they always appear in the following format:
 
 ```
 {
-  ...
   ACTION_NAME: {
     /**
      * Optional attributes - only present if you defined them
-     * 
      */
      
     name: 'name',
@@ -701,13 +699,14 @@ Regardless of which syntax you used to define the keymap, they always appear in 
      * Attributes always present
      * /
     sequences: [
-      ...
       {
         action: 'keydown',
         sequence: 'alt+s'
-      }
+      },
+      // ...
     ]
-  } 
+  },
+  // ... 
 }
 ```
 

--- a/examples/src/App.js
+++ b/examples/src/App.js
@@ -5,20 +5,20 @@ import Node from './Node';
 import HOCWrappedNode from './HOCWrappedNode';
 
 const keyMap = {
-  DELETE: { sequence: 'backspace', action: 'keyup'},
-  EXPAND: 'alt+up',
-  CONTRACT: 'alt+down',
-  MOVE_UP: 'up',
-  MOVE_DOWN: 'down',
-  MOVE_LEFT: 'left',
-  MOVE_RIGHT: 'right'
+  DELETE: { name: 'Disable square', sequence: 'backspace', action: 'keyup'},
+  EXPAND: { name: 'Expand square area', sequence: 'alt+up' },
+  CONTRACT: { name: 'Reduce square area', sequence: 'alt+down' },
+  MOVE_UP: { name: 'Move square up', sequence: 'up' },
+  MOVE_DOWN: { name: 'Move square down', sequence: 'down' },
+  MOVE_LEFT: { name: 'Move square left', sequence: 'left' },
+  MOVE_RIGHT: { name: 'Move square right', sequence: 'right' }
 };
 
 const globalKeyMap = {
-  KONAMI: 'up up down down left right left right b a enter',
-  LOG_DOWN: {sequence: 'command', action: 'keydown'},
-  LOG_UP: {sequence: 'command', action: 'keyup'},
-  SHOW_DIALOG: { sequence: 'shift+?', action: 'keyup' },
+  KONAMI: { name: 'Konami code', sequence: 'up up down down left right left right b a enter' },
+  LOG_DOWN: { name: 'Log Cmd Down', sequence: 'command', action: 'keydown'},
+  LOG_UP: { name: 'Log Cmd Up', sequence: 'command', action: 'keyup'},
+  SHOW_DIALOG: { name: 'Display keyboard shortcuts', sequence: 'shift+?', action: 'keyup' },
 };
 
 const styles = {
@@ -93,13 +93,15 @@ class App extends React.Component {
               <tbody>
               { Object.keys(keyMap).reduce((memo, actionName) => {
                 if (filter.length === 0 || actionName.indexOf(_filter) !== -1) {
+                  const { sequences, name } = keyMap[actionName];
+
                   memo.push(
-                    <tr key={actionName}>
+                    <tr key={name || actionName}>
                       <td style={styles.KEYMAP_TABLE_CELL}>
-                        { actionName.replace('_', ' ') }
+                        { name }
                       </td>
                       <td style={styles.KEYMAP_TABLE_CELL}>
-                        { keyMap[actionName].map((keySequence) => <span key={keySequence}>{keySequence}</span>) }
+                        { sequences.map(({sequence}) => <span key={sequence}>{sequence}</span>) }
                       </td>
                     </tr>
                   )

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,14 @@ export interface KeyMapOptions {
   action: KeyEventName;
 }
 
-export type KeySequence = MouseTrapKeySequence | KeyMapOptions | Array<MouseTrapKeySequence> | Array<KeyMapOptions>;
+export interface ExtendedKeyMapOptions extends KeyMapOptions {
+  sequences: Array<MouseTrapKeySequence> | Array<KeyMapOptions>;
+  name?: string;
+  group?: string;
+  description?: string;
+}
+
+export type KeySequence = MouseTrapKeySequence | KeyMapOptions | ExtendedKeyMapOptions | Array<MouseTrapKeySequence> | Array<KeyMapOptions>;
 
 export type KeyMap = { [key in ActionName]: KeySequence };
 
@@ -180,7 +187,14 @@ export class ObserveKeys extends React.Component<HotKeysOverrideProps, {}> { }
  */
 export declare function withObserveKeys(Component: React.ComponentClass, hotKeysIgnoreOptions: HotKeysOverrideProps): ObserveKeys;
 
-export type ApplicationKeyMap = { [key in ActionName]: Array<MouseTrapKeySequence> };
+export interface KeyMapDisplayOptions {
+  sequences: Array<KeyMapOptions>;
+  name?: string;
+  group?: string;
+  description?: string;
+}
+
+export type ApplicationKeyMap = { [key in ActionName]: KeyMapDisplayOptions };
 
 /**
  * Generates and returns the application's key map, including not only those

--- a/src/utils/object/copyAttributes.js
+++ b/src/utils/object/copyAttributes.js
@@ -1,0 +1,21 @@
+import hasKey from './hasKey';
+
+/**
+ * Copies a list of attributes and their values from a source object to a target object.
+ * The attributes are only copied if they exist on the source object.
+ * @param {Object} source Object to copy the attributes from
+ * @param {Object} target Object to copy the attributes to
+ * @param {String[]} attributes List of attributes to copy
+ * @return {Object} The target object, now with the copied attributes
+ */
+function copyAttributes(source, target, attributes) {
+  attributes.forEach((attributeName) => {
+    if (hasKey(source, attributeName)) {
+      target[attributeName] = source[attributeName];
+    }
+  });
+
+  return target;
+}
+
+export default copyAttributes;

--- a/src/withHotKeys.js
+++ b/src/withHotKeys.js
@@ -67,11 +67,16 @@ function withHotKeys(Component, hotKeysOptions = {}) {
        *           KeyEventDescription
        * @property {KeyEventName} action - The keyboard state required to satisfy a
        *           KeyEventDescription
+       * @property {String} name - The name of the action, to be displayed to the end user
+       * @property {String} description - A description of the action, to be displayed to
+       *           the end user
+       * @property {String} group - A group the action belongs to, to aid in showing similar
+       *           actions to the user
        */
 
       /**
        * A description of key sequence of one or more key combinations
-       * @typedef {MouseTrapKeySequence|KeyMapOptions|Array<MouseTrapKeySequence>} KeyEventDescription
+       * @typedef {MouseTrapKeySequence|KeyEventOptions|Array<MouseTrapKeySequence>} KeyEventDescription
        */
 
       /**

--- a/test/HotKeys/SpecifyingKeyMapUsingObjects.spec.js
+++ b/test/HotKeys/SpecifyingKeyMapUsingObjects.spec.js
@@ -8,124 +8,20 @@ import KeyCode from '../support/Key';
 import FocusableElement from '../support/FocusableElement';
 
 describe('Specifying key map using objects:', () => {
-  context('when a keydown keymap is specified as an object', () => {
-    beforeEach(function () {
-      this.keyMap = {
-        'ACTION1': {
-          sequence: 'enter',
-          action: 'keydown',
-        },
-      };
-
-      this.handler = sinon.spy();
-
-      this.handlers = {
-        'ACTION1': this.handler,
-      };
-
-      this.wrapper = mount(
-        <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
-          <div className="childElement" />
-        </HotKeys>
-      );
-
-      this.targetElement = new FocusableElement(this.wrapper, '.childElement');
-      this.targetElement.focus();
-    });
-
-    it('then calls the correct handler when a key is pressed that matches the keyMap', function() {
-      this.targetElement.keyDown(KeyCode.ENTER);
-
-      expect(this.handler).to.have.been.calledOnce;
-    });
-  });
-
-  context('when a keyup keymap is specified as an object', () => {
-    beforeEach(function () {
-      this.keyMap = {
-        'ACTION1': {
-          sequence: 'enter',
-          action: 'keyup',
-        },
-      };
-
-      this.handler = sinon.spy();
-
-      this.handlers = {
-        'ACTION1': this.handler,
-      };
-
-      this.wrapper = mount(
-        <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
-          <div className="childElement" />
-        </HotKeys>
-      );
-
-      this.targetElement = new FocusableElement(this.wrapper, '.childElement');
-      this.targetElement.focus();
-    });
-
-    it('then calls the correct handler when a key is pressed that matches the keyMap', function() {
-      this.targetElement.keyDown(KeyCode.ENTER);
-      this.targetElement.keyUp(KeyCode.ENTER);
-
-      expect(this.handler).to.have.been.called;
-    });
-  });
-
-  context('when a keypress keymap is specified as an object', () => {
-    beforeEach(function () {
-      this.keyMap = {
-        'ACTION1': {
-          sequence: 'a',
-          action: 'keypress',
-        },
-      };
-
-      this.handler = sinon.spy();
-
-      this.handlers = {
-        'ACTION1': this.handler,
-      };
-
-      this.wrapper = mount(
-        <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
-          <div className="childElement" />
-        </HotKeys>
-      );
-
-      this.targetElement = new FocusableElement(this.wrapper, '.childElement');
-      this.targetElement.focus();
-    });
-
-    it('then calls the correct handler when a key is pressed that matches the keyMap', function() {
-      this.targetElement.keyDown(KeyCode.A);
-      this.targetElement.keyPress(KeyCode.A);
-
-      expect(this.handler).to.have.been.called;
-    });
-  });
-
-  context('when several key events are for the same key are specified as an object', () => {
-    context('and the component is in focus', () => {
+  context('when using a root object to specify sequence attributes', () => {
+    context('for a keydown action', () => {
       beforeEach(function () {
         this.keyMap = {
-          'KEY_DOWN': {
-            sequence: 'command',
+          'ACTION1': {
+            sequence: 'enter',
             action: 'keydown',
           },
-          'KEY_UP': {
-            sequence: 'command',
-            action: 'keyup',
-          }
         };
 
-        this.keyDownHandler = sinon.spy();
-        this.keyUpHandler = sinon.spy();
+        this.handler = sinon.spy();
 
         this.handlers = {
-          'KEY_DOWN': this.keyDownHandler,
-          'KEY_UP': this.keyUpHandler,
+          'ACTION1': this.handler,
         };
 
         this.wrapper = mount(
@@ -138,43 +34,31 @@ describe('Specifying key map using objects:', () => {
         this.targetElement.focus();
       });
 
-      it('then calls the correct handler for each event', function() {
-        this.targetElement.keyDown(KeyCode.COMMAND);
+      it('then calls the correct handler when a key is pressed that matches the keyMap', function() {
+        this.targetElement.keyDown(KeyCode.ENTER);
 
-        expect(this.keyDownHandler).to.have.been.called;
-
-        this.targetElement.keyUp(KeyCode.COMMAND);
-
-        expect(this.keyUpHandler).to.have.been.called;
+        expect(this.handler).to.have.been.calledOnce;
       });
     });
 
-    context('and a child HotKeys component is in focus', () => {
+    context('for a keyup action', () => {
       beforeEach(function () {
         this.keyMap = {
-          'KEY_DOWN': {
-            sequence: 'command',
-            action: 'keydown',
-          },
-          'KEY_UP': {
-            sequence: 'command',
+          'ACTION1': {
+            sequence: 'enter',
             action: 'keyup',
-          }
+          },
         };
 
-        this.keyDownHandler = sinon.spy();
-        this.keyUpHandler = sinon.spy();
+        this.handler = sinon.spy();
 
         this.handlers = {
-          'KEY_DOWN': this.keyDownHandler,
-          'KEY_UP': this.keyUpHandler,
+          'ACTION1': this.handler,
         };
 
         this.wrapper = mount(
           <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
-            <HotKeys>
-              <div className="childElement" />
-            </HotKeys>
+            <div className="childElement" />
           </HotKeys>
         );
 
@@ -182,46 +66,407 @@ describe('Specifying key map using objects:', () => {
         this.targetElement.focus();
       });
 
-      it('then calls the correct handler for each event', function() {
-        this.targetElement.keyDown(KeyCode.COMMAND);
+      it('then calls the correct handler when a key is pressed that matches the keyMap', function() {
+        this.targetElement.keyDown(KeyCode.ENTER);
+        this.targetElement.keyUp(KeyCode.ENTER);
 
-        expect(this.keyDownHandler).to.have.been.called;
+        expect(this.handler).to.have.been.called;
+      });
+    });
 
-        this.targetElement.keyUp(KeyCode.COMMAND);
+    context('for a keypress action', () => {
+      beforeEach(function () {
+        this.keyMap = {
+          'ACTION1': {
+            sequence: 'a',
+            action: 'keypress',
+          },
+        };
 
-        expect(this.keyUpHandler).to.have.been.called;
+        this.handler = sinon.spy();
+
+        this.handlers = {
+          'ACTION1': this.handler,
+        };
+
+        this.wrapper = mount(
+          <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+            <div className="childElement" />
+          </HotKeys>
+        );
+
+        this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+        this.targetElement.focus();
+      });
+
+      it('then calls the correct handler when a key is pressed that matches the keyMap', function() {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+
+        expect(this.handler).to.have.been.called;
+      });
+    });
+
+    context('for actions defined to different key events for the same key', () => {
+      context('and the component is in focus', () => {
+        beforeEach(function () {
+          this.keyMap = {
+            'KEY_DOWN': {
+              sequence: 'command',
+              action: 'keydown',
+            },
+            'KEY_UP': {
+              sequence: 'command',
+              action: 'keyup',
+            }
+          };
+
+          this.keyDownHandler = sinon.spy();
+          this.keyUpHandler = sinon.spy();
+
+          this.handlers = {
+            'KEY_DOWN': this.keyDownHandler,
+            'KEY_UP': this.keyUpHandler,
+          };
+
+          this.wrapper = mount(
+            <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+              <div className="childElement" />
+            </HotKeys>
+          );
+
+          this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+          this.targetElement.focus();
+        });
+
+        it('then calls the correct handler for each event', function() {
+          this.targetElement.keyDown(KeyCode.COMMAND);
+
+          expect(this.keyDownHandler).to.have.been.called;
+
+          this.targetElement.keyUp(KeyCode.COMMAND);
+
+          expect(this.keyUpHandler).to.have.been.called;
+        });
+      });
+
+      context('and a child HotKeys component is in focus', () => {
+        beforeEach(function () {
+          this.keyMap = {
+            'KEY_DOWN': {
+              sequence: 'command',
+              action: 'keydown',
+            },
+            'KEY_UP': {
+              sequence: 'command',
+              action: 'keyup',
+            }
+          };
+
+          this.keyDownHandler = sinon.spy();
+          this.keyUpHandler = sinon.spy();
+
+          this.handlers = {
+            'KEY_DOWN': this.keyDownHandler,
+            'KEY_UP': this.keyUpHandler,
+          };
+
+          this.wrapper = mount(
+            <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+              <HotKeys>
+                <div className="childElement" />
+              </HotKeys>
+            </HotKeys>
+          );
+
+          this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+          this.targetElement.focus();
+        });
+
+        it('then calls the correct handler for each event', function() {
+          this.targetElement.keyDown(KeyCode.COMMAND);
+
+          expect(this.keyDownHandler).to.have.been.called;
+
+          this.targetElement.keyUp(KeyCode.COMMAND);
+
+          expect(this.keyUpHandler).to.have.been.called;
+        });
+      });
+    });
+
+    context('for a keymap, without the action', () => {
+      beforeEach(function () {
+        this.keyMap = {
+          'ACTION': {
+            sequence: 'a',
+          },
+        };
+
+        this.handler = sinon.spy();
+
+        this.handlers = {
+          'ACTION': this.handler,
+        };
+
+        this.wrapper = mount(
+          <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+            <div className="childElement" />
+          </HotKeys>
+        );
+
+        this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+        this.targetElement.focus();
+      });
+
+      it('then calls the correct handler when a key is pressed that matches the keyMap', function() {
+        this.targetElement.keyDown(KeyCode.A);
+
+        expect(this.handler).to.have.been.called;
       });
     });
   });
 
-  context('when a keymap is specified as an object without the action', () => {
-    beforeEach(function () {
-      this.keyMap = {
-        'ACTION': {
-          sequence: 'a',
-        },
-      };
+  context('when using an object with the sequences attribute', () => {
+    context('with an array of strings', () => {
+      beforeEach(function () {
+        this.keyMap = {
+          'ACTION1': {
+            sequences: ['enter'],
+          },
+        };
 
-      this.handler = sinon.spy();
+        this.handler = sinon.spy();
 
-      this.handlers = {
-        'ACTION': this.handler,
-      };
+        this.handlers = {
+          'ACTION1': this.handler,
+        };
 
-      this.wrapper = mount(
-        <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
-          <div className="childElement" />
-        </HotKeys>
-      );
+        this.wrapper = mount(
+          <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+            <div className="childElement" />
+          </HotKeys>
+        );
 
-      this.targetElement = new FocusableElement(this.wrapper, '.childElement');
-      this.targetElement.focus();
+        this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+        this.targetElement.focus();
+      });
+
+      it('then calls the correct handler when a key is pressed that matches the keyMap', function() {
+        this.targetElement.keyDown(KeyCode.ENTER);
+
+        expect(this.handler).to.have.been.calledOnce;
+      });
     });
 
-    it('then calls the correct handler when a key is pressed that matches the keyMap', function() {
-      this.targetElement.keyDown(KeyCode.A);
+    context('for a keydown action', () => {
+      beforeEach(function () {
+        this.keyMap = {
+          'ACTION1': {
+            sequences: [{ sequence: 'enter', action: 'keydown' }],
+          },
+        };
 
-      expect(this.handler).to.have.been.called;
+        this.handler = sinon.spy();
+
+        this.handlers = {
+          'ACTION1': this.handler,
+        };
+
+        this.wrapper = mount(
+          <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+            <div className="childElement" />
+          </HotKeys>
+        );
+
+        this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+        this.targetElement.focus();
+      });
+
+      it('then calls the correct handler when a key is pressed that matches the keyMap', function() {
+        this.targetElement.keyDown(KeyCode.ENTER);
+
+        expect(this.handler).to.have.been.calledOnce;
+      });
+    });
+
+    context('for a keyup action', () => {
+      beforeEach(function () {
+        this.keyMap = {
+          'ACTION1': {
+            sequences: [{ sequence: 'enter', action: 'keyup' }],
+          },
+        };
+
+        this.handler = sinon.spy();
+
+        this.handlers = {
+          'ACTION1': this.handler,
+        };
+
+        this.wrapper = mount(
+          <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+            <div className="childElement" />
+          </HotKeys>
+        );
+
+        this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+        this.targetElement.focus();
+      });
+
+      it('then calls the correct handler when a key is pressed that matches the keyMap', function() {
+        this.targetElement.keyDown(KeyCode.ENTER);
+        this.targetElement.keyUp(KeyCode.ENTER);
+
+        expect(this.handler).to.have.been.called;
+      });
+    });
+
+    context('for a keypress action', () => {
+      beforeEach(function () {
+        this.keyMap = {
+          'ACTION1': {
+            sequences: [{ sequence: 'a', action: 'keypress' }],
+          },
+        };
+
+        this.handler = sinon.spy();
+
+        this.handlers = {
+          'ACTION1': this.handler,
+        };
+
+        this.wrapper = mount(
+          <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+            <div className="childElement" />
+          </HotKeys>
+        );
+
+        this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+        this.targetElement.focus();
+      });
+
+      it('then calls the correct handler when a key is pressed that matches the keyMap', function() {
+        this.targetElement.keyDown(KeyCode.A);
+        this.targetElement.keyPress(KeyCode.A);
+
+        expect(this.handler).to.have.been.called;
+      });
+    });
+
+    context('for actions defined to different key events for the same key', () => {
+      context('and the component is in focus', () => {
+        beforeEach(function () {
+          this.keyMap = {
+            'KEY_DOWN': {
+              sequences: [{ sequence: 'command', action: 'keydown' }],
+            },
+            'KEY_UP': {
+              sequences: [{ sequence: 'command', action: 'keyup' }],
+            },
+          };
+
+          this.keyDownHandler = sinon.spy();
+          this.keyUpHandler = sinon.spy();
+
+          this.handlers = {
+            'KEY_DOWN': this.keyDownHandler,
+            'KEY_UP': this.keyUpHandler,
+          };
+
+          this.wrapper = mount(
+            <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+              <div className="childElement" />
+            </HotKeys>
+          );
+
+          this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+          this.targetElement.focus();
+        });
+
+        it('then calls the correct handler for each event', function() {
+          this.targetElement.keyDown(KeyCode.COMMAND);
+
+          expect(this.keyDownHandler).to.have.been.called;
+
+          this.targetElement.keyUp(KeyCode.COMMAND);
+
+          expect(this.keyUpHandler).to.have.been.called;
+        });
+      });
+
+      context('and a child HotKeys component is in focus', () => {
+        beforeEach(function () {
+          this.keyMap = {
+            'KEY_DOWN': {
+              sequences: [{ sequence: 'command', action: 'keydown' }],
+            },
+            'KEY_UP': {
+              sequences: [{ sequence: 'command', action: 'keyup' }],
+            },
+          };
+
+          this.keyDownHandler = sinon.spy();
+          this.keyUpHandler = sinon.spy();
+
+          this.handlers = {
+            'KEY_DOWN': this.keyDownHandler,
+            'KEY_UP': this.keyUpHandler,
+          };
+
+          this.wrapper = mount(
+            <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+              <HotKeys>
+                <div className="childElement" />
+              </HotKeys>
+            </HotKeys>
+          );
+
+          this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+          this.targetElement.focus();
+        });
+
+        it('then calls the correct handler for each event', function() {
+          this.targetElement.keyDown(KeyCode.COMMAND);
+
+          expect(this.keyDownHandler).to.have.been.called;
+
+          this.targetElement.keyUp(KeyCode.COMMAND);
+
+          expect(this.keyUpHandler).to.have.been.called;
+        });
+      });
+    });
+
+    context('for a keymap, without the action', () => {
+      beforeEach(function () {
+        this.keyMap = {
+          'ACTION': {
+            sequences: [{ sequence: 'a' }],
+          },
+        };
+
+        this.handler = sinon.spy();
+
+        this.handlers = {
+          'ACTION': this.handler,
+        };
+
+        this.wrapper = mount(
+          <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+            <div className="childElement" />
+          </HotKeys>
+        );
+
+        this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+        this.targetElement.focus();
+      });
+
+      it('then calls the correct handler when a key is pressed that matches the keyMap', function() {
+        this.targetElement.keyDown(KeyCode.A);
+
+        expect(this.handler).to.have.been.called;
+      });
     });
   });
 });

--- a/test/getApplicationKeyMap/GettingApplicationKeyMap.js
+++ b/test/getApplicationKeyMap/GettingApplicationKeyMap.js
@@ -28,7 +28,7 @@ describe('Getting the application key map:', () => {
 
     it('generates the correct application key map', function() {
       expect(getApplicationKeyMap()).to.eql({
-        'ACTION1': ['enter']
+        'ACTION1': { sequences: [{ sequence: 'enter' }] }
       })
     });
   });
@@ -39,6 +39,9 @@ describe('Getting the application key map:', () => {
         'ACTION1': {
           sequence: 'enter',
           action: 'keydown',
+          name: 'NAME',
+          description: 'DESC',
+          group: 'GROUP'
         },
       };
 
@@ -57,7 +60,154 @@ describe('Getting the application key map:', () => {
 
     it('generates the correct application key map', function() {
       expect(getApplicationKeyMap()).to.eql({
-        'ACTION1': ['enter']
+        'ACTION1': {
+          sequences: [{ sequence: 'enter', action: 'keydown' }],
+          name: 'NAME',
+          description: 'DESC',
+          group: 'GROUP'
+        }
+      })
+    });
+  });
+
+  context('when a keydown keymap is specified as an array of strings', () => {
+    beforeEach(function () {
+      this.keyMap = {
+        'ACTION1': ['enter','shift'],
+      };
+
+      this.handler = sinon.spy();
+
+      this.handlers = {
+        'ACTION1': this.handler,
+      };
+
+      this.wrapper = mount(
+        <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+          <div className="childElement" />
+        </HotKeys>
+      );
+    });
+
+    it('generates the correct application key map', function() {
+      expect(getApplicationKeyMap()).to.eql({
+        'ACTION1': { sequences: [{ sequence: 'enter' }, { sequence: 'shift' }] }
+      })
+    });
+  });
+
+  context('when a keydown keymap is specified as an array of objects', () => {
+    beforeEach(function () {
+      this.keyMap = {
+        'ACTION1': [{
+          sequence: 'enter',
+          action: 'keydown',
+        }, {
+          sequence: 'shift',
+          action: 'keydown',
+        }],
+      };
+
+      this.handler = sinon.spy();
+
+      this.handlers = {
+        'ACTION1': this.handler,
+      };
+
+      this.wrapper = mount(
+        <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+          <div className="childElement" />
+        </HotKeys>
+      );
+    });
+
+    it('generates the correct application key map', function() {
+      expect(getApplicationKeyMap()).to.eql({
+        'ACTION1': { sequences: [
+          { sequence: 'enter', action: 'keydown' },
+          { sequence: 'shift', action: 'keydown' }]
+        }
+      })
+    });
+  });
+
+  context('when a keydown keymap is specified as object with sequences attribute of an array of strings', () => {
+    beforeEach(function () {
+      this.keyMap = {
+        'ACTION1': {
+          sequences: ['enter', 'shift'],
+          name: 'NAME',
+          description: 'DESC',
+          group: 'GROUP'
+        },
+      };
+
+      this.handler = sinon.spy();
+
+      this.handlers = {
+        'ACTION1': this.handler,
+      };
+
+      this.wrapper = mount(
+        <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+          <div className="childElement" />
+        </HotKeys>
+      );
+    });
+
+    it('generates the correct application key map', function() {
+      expect(getApplicationKeyMap()).to.eql({
+        'ACTION1': {
+          sequences: [
+            { sequence: 'enter' },
+            { sequence: 'shift' }
+          ],
+          name: 'NAME',
+          description: 'DESC',
+          group: 'GROUP'
+        }
+      })
+    });
+  });
+
+  context('when a keydown keymap is specified as object with sequences attribute of an array of objects', () => {
+    beforeEach(function () {
+      this.keyMap = {
+        'ACTION1': {
+          sequences: [
+            {sequence: 'enter', action: 'keydown'},
+            {sequence: 'shift', action: 'keydown'}
+          ],
+          name: 'NAME',
+          description: 'DESC',
+          group: 'GROUP'
+        },
+      };
+
+      this.handler = sinon.spy();
+
+      this.handlers = {
+        'ACTION1': this.handler,
+      };
+
+      this.wrapper = mount(
+        <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+          <div className="childElement" />
+        </HotKeys>
+      );
+    });
+
+    it('generates the correct application key map', function() {
+      expect(getApplicationKeyMap()).to.eql({
+        'ACTION1': {
+          sequences: [
+            { sequence: 'enter', action: 'keydown' },
+            { sequence: 'shift', action: 'keydown' }
+          ],
+          name: 'NAME',
+          description: 'DESC',
+          group: 'GROUP'
+        }
       })
     });
   });
@@ -77,7 +227,11 @@ describe('Getting the application key map:', () => {
 
     it('generates the correct application key map', function() {
       expect(getApplicationKeyMap()).to.eql({
-        'ACTION1': ['enter']
+        'ACTION1': {
+          sequences: [
+            { sequence: 'enter' }
+          ]
+        }
       })
     });
   });
@@ -114,8 +268,8 @@ describe('Getting the application key map:', () => {
 
     it('generates the correct application key map', function() {
       expect(getApplicationKeyMap()).to.eql({
-        'ACTION1': ['enter'],
-        'ACTION2': ['enter']
+        'ACTION1': { sequences: [{ sequence: 'enter' }] },
+        'ACTION2': { sequences: [{ sequence: 'enter' }] }
       })
     });
   });
@@ -132,9 +286,9 @@ describe('Getting the application key map:', () => {
 
     it('generates the correct application key map', function() {
       expect(getApplicationKeyMap()).to.eql({
-        'ACTION1': ['enter'],
-        'ACTION2': ['enter'],
-        'ACTION3': ['shift']
+        'ACTION1': { sequences: [{ sequence: 'enter' }] },
+        'ACTION2': { sequences: [{ sequence: 'enter' }] },
+        'ACTION3': { sequences: [{ sequence: 'shift' }] }
       })
     });
   });
@@ -153,10 +307,10 @@ describe('Getting the application key map:', () => {
 
     it('generates the correct application key map', function() {
       expect(getApplicationKeyMap()).to.eql({
-        'ACTION0': ['cmd'],
-        'ACTION1': ['enter'],
-        'ACTION2': ['enter'],
-        'ACTION3': ['shift']
+        'ACTION0': { sequences: [{ sequence: 'cmd' }] },
+        'ACTION1': { sequences: [{ sequence: 'enter' }] },
+        'ACTION2': { sequences: [{ sequence: 'enter' }] },
+        'ACTION3': { sequences: [{ sequence: 'shift' }] }
       })
     });
   });


### PR DESCRIPTION
# Context

The current ability to display an application's keymap was implemented as somewhat of a litmus test to see how useful users of `react-hotkeys` would find it. It didn't take long for the capacity of the feature to be exceeded, and more functionality to be requested (#154).

# This pull request

## New features

* Adds the ability for users to specify `name`, `description` and `group` attributes for each key map that they define.

This can be done using the existing object syntax:

```javascript
{
  'ACTION1': {
    sequence: 'enter',
    name: 'NAME',
    description: 'DESC',
    group: 'GROUP'
  }
}
```
Or using an new syntax, for when the user also has multiple alternative key sequences to trigger the same action:

```javascript
{
  'ACTION1': {
    sequences: ['enter', 'shift'],
    name: 'NAME',
    description: 'DESC',
    group: 'GROUP'
  }
}
```

## Breaking changes

* Necessarily changes the format of the object returned by `getApplicationKeyMap` to accommodate the new attribute information, to look like the following:

```
{
  ...
  ACTION_NAME: {
    /**
     * Optional attributes - only present if you defined them
     */
     
    name: 'name',
    group: 'group',
    description: 'description',
    
    /**
     * Attributes always present
     * /
    sequences: [
      ...
      {
        action: 'keydown',
        sequence: 'alt+s'
      }
    ]
  } 
}
```

## Improvements

* Adds tests to verify the new syntax (leaning on existing tests to prevent regressions)
* Updates the Readme with new information about defining key maps and retrieving the application key map