### PR TITLE
🐛 Fix #182: Reset handle resolution state when HotKeys props are updated

### DIFF
--- a/src/lib/strategies/FocusOnlyKeyEventStrategy.js
+++ b/src/lib/strategies/FocusOnlyKeyEventStrategy.js
@@ -228,6 +228,11 @@ class FocusOnlyKeyEventStrategy extends AbstractKeyEventStrategy {
       'Received new props.',
     );
 
+    /**
+     * Reset handler resolution state
+     */
+    this._initHandlerResolutionState();
+
     const component = this._getComponent(componentId);
 
     this.logger.verbose(

--- a/test/HotKeys/focus-only/ChangingKeyMapAndHandlersAfterMount.spec.js
+++ b/test/HotKeys/focus-only/ChangingKeyMapAndHandlersAfterMount.spec.js
@@ -33,7 +33,7 @@ describe('Changing keyMap and handlers after mount:', function () {
       this.targetElement.focus();
     });
 
-    describe('when a keyMap action\'s key sequence is changed', () => {
+    describe('and a keyMap action\'s key sequence is changed', () => {
       beforeEach(function () {
         this.wrapper.setProps({ keyMap: { 'ACTION': 'b' }, handlers: this.handlers })
       });
@@ -79,7 +79,7 @@ describe('Changing keyMap and handlers after mount:', function () {
 
     });
 
-    describe('when a keyMap action\'s key sequence is changed', () => {
+    describe('and a keyMap action\'s key sequence is changed', () => {
       beforeEach(function () {
         this.wrapper.setProps({ keyMap: { 'ACTION': 'b' }, handlers: this.handlers })
       });
@@ -92,7 +92,7 @@ describe('Changing keyMap and handlers after mount:', function () {
       });
     });
 
-    describe('when the action associated with a key sequence is changed', () => {
+    describe('and the action associated with a key sequence is changed', () => {
       beforeEach(function () {
         this.wrapper.setProps({ keyMap: { 'ACTION2': 'a' }, handlers: this.handlers })
       });
@@ -108,7 +108,7 @@ describe('Changing keyMap and handlers after mount:', function () {
       });
     });
 
-    describe('when the a new action is added to the keymap', () => {
+    describe('and the a new action is added to the keymap', () => {
       beforeEach(function () {
         this.wrapper.setProps({ keyMap: { ...this.keyMap, 'ACTION2': 'b' }, handlers: this.handlers })
       });
@@ -124,7 +124,7 @@ describe('Changing keyMap and handlers after mount:', function () {
       });
     });
 
-    describe('when the an action is removed from the keymap', () => {
+    describe('and the an action is removed from the keymap', () => {
       beforeEach(function () {
         this.wrapper.setProps({ keyMap: { }, handlers: this.handlers })
       });
@@ -136,8 +136,8 @@ describe('Changing keyMap and handlers after mount:', function () {
       });
     });
 
-    context('when no keys have been pressed yet', () => {
-      describe('when a keyMap\'s handler is changed', () => {
+    context('and no keys have been pressed yet', () => {
+      describe('and a keyMap\'s handler is changed', () => {
         beforeEach(function () {
           this.wrapper.setProps({ keyMap: this.keyMap, handlers: { 'ACTION': this.handler2 } })
         });
@@ -151,8 +151,8 @@ describe('Changing keyMap and handlers after mount:', function () {
       });
     });
 
-    context('when keys have been pressed (and handlers attempted to be resolved)', () => {
-      describe('when a keyMap\'s handler is changed', () => {
+    context('and keys have been pressed (and handlers attempted to be resolved)', () => {
+      describe('and a keyMap\'s handler is changed', () => {
         beforeEach(function () {
           this.targetElement.keyDown(KeyCode.A);
           expect(this.handler).to.have.been.calledOnce;
@@ -169,7 +169,7 @@ describe('Changing keyMap and handlers after mount:', function () {
       });
     });
 
-    describe('when a new handler is added to the keymap', () => {
+    describe('and a new handler is added to the keymap', () => {
       beforeEach(function () {
         this.handler3 = sinon.spy();
 
@@ -189,7 +189,7 @@ describe('Changing keyMap and handlers after mount:', function () {
       });
     });
 
-    describe('when a handler is removed from keymap', () => {
+    describe('and a handler is removed from keymap', () => {
       beforeEach(function () {
         this.handler3 = sinon.spy();
 

--- a/test/HotKeys/focus-only/ChangingKeyMapAndHandlersAfterMount.spec.js
+++ b/test/HotKeys/focus-only/ChangingKeyMapAndHandlersAfterMount.spec.js
@@ -136,17 +136,36 @@ describe('Changing keyMap and handlers after mount:', function () {
       });
     });
 
-    describe('when a keyMap\'s handler is changed', () => {
-      beforeEach(function () {
-        this.wrapper.setProps({ keyMap: this.keyMap, handlers: { 'ACTION': this.handler2 } })
+    context('when no keys have been pressed yet', () => {
+      describe('when a keyMap\'s handler is changed', () => {
+        beforeEach(function () {
+          this.wrapper.setProps({ keyMap: this.keyMap, handlers: { 'ACTION': this.handler2 } })
+        });
+
+        it('then the new handler is used', function() {
+          this.targetElement.keyDown(KeyCode.A);
+
+          expect(this.handler).to.not.have.been.called;
+          expect(this.handler2).to.have.been.calledOnce;
+        });
       });
+    });
 
-      it('then the new sequence is used', function() {
+    context('when keys have been pressed (and handlers attempted to be resolved)', () => {
+      describe('when a keyMap\'s handler is changed', () => {
+        beforeEach(function () {
+          this.targetElement.keyDown(KeyCode.A);
+          expect(this.handler).to.have.been.calledOnce;
 
-        this.targetElement.keyDown(KeyCode.A);
+          this.wrapper.setProps({ keyMap: this.keyMap, handlers: { 'ACTION': this.handler2 } })
+        });
 
-        expect(this.handler).to.not.have.been.called;
-        expect(this.handler2).to.have.been.calledOnce;
+        it('then the new handler is used (https://github.com/greena13/react-hotkeys/issues/182)', function() {
+          this.targetElement.keyDown(KeyCode.A);
+
+          expect(this.handler).to.have.been.calledOnce;
+          expect(this.handler2).to.have.been.calledOnce;
+        });
       });
     });
 


### PR DESCRIPTION
# Context

Back in #150 the handler state not being reset when a new `<GlobalHotKeys />` is mounted was fixed, but the analogous situation for `<HotKeys />` was left unfixed (when a `<HotKeys />` component updates its props). This resulted in the issue #182, whereby if a `<HotKeys />` component's props had changed (and the `allowChanges` prop was used) and a key had already been pressed (triggering the building of a handler resolution data structure), then the key handler was *not* updated, and the old one was used.

# This pull request

* Resets the `<HotKeys />` component's handler resolution state whenever it updates its props (and `allowChanges` is true).
* Adds a test to cover this situation in the future