### PR TITLE
🐛 Fix #177: Ignore repeated keyboard events when a key is held down

### DIFF
--- a/README.md
+++ b/README.md
@@ -1074,6 +1074,12 @@ configure({
   ignoreKeymapAndHandlerChangesByDefault: true,
 
   /**
+   * Whether to ignore repeated keyboard events when a key is being held down
+   * @type {Boolean}
+   */
+  ignoreRepeatedEventsWhenKeyHeldDown: true,
+  
+  /**
    * Whether React HotKeys should simulate keypress events for the keys that do not
    * natively emit them.
    * @type {Boolean}

--- a/index.d.ts
+++ b/index.d.ts
@@ -255,6 +255,11 @@ export interface ConfigurationOptions {
   ignoreEventsCondition?: (keyEvent: KeyboardEvent) => boolean,
 
   /**
+   * Whether to ignore repeated keyboard events when a key is being held down
+   */
+  ignoreRepeatedEventsWhenKeyHeldDown?: boolean,
+
+  /**
    * Whether React HotKeys should simulate keypress events for the keys that do not
    * natively emit them.
    */

--- a/src/lib/Configuration.js
+++ b/src/lib/Configuration.js
@@ -60,7 +60,7 @@ const _defaultConfiguration = {
    * @type {Function<KeyboardEvent>}
    */
   ignoreEventsCondition: (event) => {
-    const { target } = event;
+    const {target} = event;
 
     if (target && target.tagName) {
       const tagName = target.tagName.toLowerCase();
@@ -70,6 +70,12 @@ const _defaultConfiguration = {
       return false;
     }
   },
+
+  /**
+   * Whether to ignore repeated keyboard events when a key is being held down
+   * @type {Boolean}
+   */
+  ignoreRepeatedEventsWhenKeyHeldDown: true,
 
   /**
    * Whether React HotKeys should simulate keypress events for the keys that do not
@@ -128,23 +134,23 @@ class Configuration {
    * @see _configuration
    */
   static init(configuration) {
-    const { ignoreTags } = configuration;
+    const {ignoreTags} = configuration;
 
     if (ignoreTags) {
       configuration._ignoreTagsDict = dictionaryFrom(configuration.ignoreTags);
     }
 
-    if(process.env.NODE_ENV === 'production') {
+    if (process.env.NODE_ENV === 'production') {
       if (['verbose', 'debug', 'info'].indexOf(configuration.logLevel) !== -1) {
         console.warn(
           `React HotKeys: You have requested log level '${configuration.logLevel}' but for performance reasons, logging below severity level 'warning' is disabled in production. Please use the development build for complete logs.`
-        )
+        );
       }
     }
 
     Object.keys(configuration).forEach((key) => {
-      this.set(key, configuration[key])
-    })
+      this.set(key, configuration[key]);
+    });
   }
 
   /**

--- a/src/lib/strategies/FocusOnlyKeyEventStrategy.js
+++ b/src/lib/strategies/FocusOnlyKeyEventStrategy.js
@@ -422,7 +422,7 @@ class FocusOnlyKeyEventStrategy extends AbstractKeyEventStrategy {
     if (event.repeat && Configuration.option('ignoreRepeatedEventsWhenKeyHeldDown')) {
       this.logger.debug(
         this._logPrefix(componentId),
-        `Ignored repeated ${describeKeyEvent(event, _key, KeyEventBitmapIndex.keydown)} event.`
+        `Ignored repeated ${describeKeyEvent(event, _key, KeyEventBitmapIndex.keypress)} event.`
       );
 
       this._ignoreEvent(event, componentId);

--- a/src/lib/strategies/FocusOnlyKeyEventStrategy.js
+++ b/src/lib/strategies/FocusOnlyKeyEventStrategy.js
@@ -296,6 +296,17 @@ class FocusOnlyKeyEventStrategy extends AbstractKeyEventStrategy {
   handleKeydown(event, focusTreeId, componentId, options = {}) {
     const _key = normalizeKeyName(event.key);
 
+    if (event.repeat && Configuration.option('ignoreRepeatedEventsWhenKeyHeldDown')) {
+      this.logger.debug(
+        this._logPrefix(componentId),
+        `Ignored repeated ${describeKeyEvent(event, _key, KeyEventBitmapIndex.keydown)} event.`
+      );
+
+      this._ignoreEvent(event, componentId);
+
+      return true;
+    }
+
     if (focusTreeId !== this.focusTreeId) {
       this.logger.debug(
         this._logPrefix(componentId),
@@ -407,6 +418,17 @@ class FocusOnlyKeyEventStrategy extends AbstractKeyEventStrategy {
    */
   handleKeypress(event, focusTreeId, componentId, options) {
     const _key = normalizeKeyName(event.key);
+
+    if (event.repeat && Configuration.option('ignoreRepeatedEventsWhenKeyHeldDown')) {
+      this.logger.debug(
+        this._logPrefix(componentId),
+        `Ignored repeated ${describeKeyEvent(event, _key, KeyEventBitmapIndex.keydown)} event.`
+      );
+
+      this._ignoreEvent(event, componentId);
+
+      return true;
+    }
 
     const shouldDiscardFocusTreeId = focusTreeId !== this.focusTreeId;
 

--- a/src/lib/strategies/GlobalKeyEventStrategy.js
+++ b/src/lib/strategies/GlobalKeyEventStrategy.js
@@ -253,6 +253,15 @@ class GlobalKeyEventStrategy extends AbstractKeyEventStrategy {
   handleKeydown(event) {
     const _key = normalizeKeyName(getEventKey(event));
 
+    if (event.repeat && Configuration.option('ignoreRepeatedEventsWhenKeyHeldDown')) {
+      this.logger.debug(
+        this._logPrefix(),
+        `Ignored repeated ${describeKeyEvent(event, _key, KeyEventBitmapIndex.keydown)} event.`
+      );
+
+      return true;
+    }
+
     this._checkForModifierFlagDiscrepancies(event, _key, KeyEventBitmapIndex.keydown);
 
     const reactAppResponse = this._howReactAppRespondedTo(
@@ -341,6 +350,15 @@ class GlobalKeyEventStrategy extends AbstractKeyEventStrategy {
    */
   handleKeypress(event) {
     const key = normalizeKeyName(getEventKey(event));
+
+    if (event.repeat && Configuration.option('ignoreRepeatedEventsWhenKeyHeldDown')) {
+      this.logger.debug(
+        this._logPrefix(),
+        `Ignored repeated ${describeKeyEvent(event, key, KeyEventBitmapIndex.keydown)} event.`
+      );
+
+      return true;
+    }
 
     /**
      * We first decide if the keypress event should be handled (to ensure the correct

--- a/src/lib/strategies/GlobalKeyEventStrategy.js
+++ b/src/lib/strategies/GlobalKeyEventStrategy.js
@@ -354,7 +354,7 @@ class GlobalKeyEventStrategy extends AbstractKeyEventStrategy {
     if (event.repeat && Configuration.option('ignoreRepeatedEventsWhenKeyHeldDown')) {
       this.logger.debug(
         this._logPrefix(),
-        `Ignored repeated ${describeKeyEvent(event, key, KeyEventBitmapIndex.keydown)} event.`
+        `Ignored repeated ${describeKeyEvent(event, key, KeyEventBitmapIndex.keypress)} event.`
       );
 
       return true;

--- a/test/lib/IgnoringRepeatedEvents.spec.js
+++ b/test/lib/IgnoringRepeatedEvents.spec.js
@@ -1,0 +1,105 @@
+import { expect } from 'chai';
+
+import Key from '../support/Key';
+import KeyEventManager from '../../src/lib/KeyEventManager';
+import Configuration from '../../src/lib/Configuration';
+import MockSyntheticEvent from '../support/MockSyntheticEvent';
+
+describe('Ignoring repeated events:', function () {
+  [
+    {
+      strategyKey: '_focusOnlyEventStrategy',
+      strategyName: 'FocusOnlyEventStrategy'
+    },
+    {
+      strategyKey: '_globalEventStrategy',
+      strategyName: 'GlobalEventStrategy'
+    }
+  ].forEach(({strategyKey, strategyName}) => {
+    context(`when the ${strategyName} receives the shift keydown event followed by a non-modifier keydown event`, () => {
+      context('and the non-modifier key repeatedly triggers keydown and keypress events', () => {
+        beforeEach(function () {
+          this.keyEventManager = new KeyEventManager();
+
+          this.eventStrategy = this.keyEventManager[strategyKey];
+
+          this.eventOptions = {
+            ignoreEventsCondition: Configuration.option('ignoreEventsCondition')
+          };
+
+          this.componentId = this.eventStrategy.registerKeyMap({});
+          this.eventStrategy.enableHotKeys(this.componentId, {}, {}, {}, {ignoreEventsCondition: Configuration.option('ignoreEventsCondition')});
+        });
+
+        it.only('then the repeated events are ignored', function () {
+          this.eventStrategy.handleKeydown(
+            new MockSyntheticEvent('keydown', {key: 'Shift'}),
+            0,
+            this.componentId,
+            this.eventOptions
+          );
+
+          expect(this.eventStrategy.keyCombinationHistory).to.eql([
+            {
+              'keys': {
+                'Shift': [
+                  [true, false, false],
+                  [true, true, false]
+                ]
+              },
+              'ids': ['Shift'],
+              'keyAliases': {}
+            }
+          ]);
+
+          this.eventStrategy.handleKeydown(
+            new MockSyntheticEvent('keydown', {key: Key.A}),
+            0,
+            this.componentId,
+            this.eventOptions
+          );
+
+          this.eventStrategy.handleKeypress(
+            new MockSyntheticEvent('keypress', {key: Key.A}),
+            0,
+            this.componentId,
+            this.eventOptions
+          );
+
+          this.eventStrategy.handleKeydown(
+            new MockSyntheticEvent('keydown', {key: Key.A, repeat: true}),
+            0,
+            this.componentId,
+            this.eventOptions
+          );
+
+          this.eventStrategy.handleKeypress(
+            new MockSyntheticEvent('keypress', {key: Key.A, repeat: true}),
+            0,
+            this.componentId,
+            this.eventOptions
+          );
+
+          expect(this.eventStrategy.keyCombinationHistory).to.eql([
+            {
+              'keys': {
+                'Shift': [
+                  [true, false, false],
+                  [true, true, false]
+                ],
+                'a': [
+                  [true, false, false],
+                  [true, true, false]
+                ]
+              },
+              'ids': ['Shift+a', 'A+Shift'],
+              'keyAliases': {
+                'A': 'a'
+              }
+            }
+          ]);
+        })
+      });
+    });
+  });
+});

--- a/test/lib/IgnoringRepeatedEvents.spec.js
+++ b/test/lib/IgnoringRepeatedEvents.spec.js
@@ -31,7 +31,7 @@ describe('Ignoring repeated events:', function () {
           this.eventStrategy.enableHotKeys(this.componentId, {}, {}, {}, {ignoreEventsCondition: Configuration.option('ignoreEventsCondition')});
         });
 
-        it.only('then the repeated events are ignored', function () {
+        it('then the repeated events are ignored', function () {
           this.eventStrategy.handleKeydown(
             new MockSyntheticEvent('keydown', {key: 'Shift'}),
             0,


### PR DESCRIPTION
# Context

When an end-user holds down certain modifier keys and a non-modifier key at the same time (e.g. `shift+a`) the browser repeatedly registers `keydown` and `keypress` events for the non-modifier key. This results in any action bound to that key combination being repeatedly called, which is unlikely what the developer intends. This has been reported as a bug in #177.

# This pull request

* Adds  a `ignoreRepeatedEventsWhenKeyHeldDown` configuration option that is `true` by default, and causes all repeated `keydown` and `keypress` events to be ignored by `react-hotkeys`.
* Adds a test that covers this new functionality
* Adds the corresponding TypeScript and Readme entries for the new `ignoreRepeatedEventsWhenKeyHeldDown` option