### PR TITLE
🐛 Fix #183: Add separate dictionary of keys that cmd hides the keyup …

### DIFF
--- a/src/const/KeysWithKeyupHiddenByCmd.js
+++ b/src/const/KeysWithKeyupHiddenByCmd.js
@@ -10,8 +10,8 @@ const KeysWithKeyupHiddenByCmd = {
   ArrowUp: true,
   ArrowDown: true,
   /**
-   * Caps lock is a strange case where it not only does not have a key press event,
-   * but it's keyup event is triggered when caps lock is toggled off
+   * Caps lock is a strange case where it not only fails to trigger a keyup event when,
+   * pressed with cmd, but it's keyup event is triggered when caps lock is toggled off
    */
   CapsLock: true,
 };

--- a/src/const/KeysWithKeyupHiddenByCmd.js
+++ b/src/const/KeysWithKeyupHiddenByCmd.js
@@ -1,0 +1,23 @@
+/**
+ * Dictionary of keys that, when pressed down with the cmd key, never trigger a keyup
+ * event in the browser
+ */
+const KeysWithKeyupHiddenByCmd = {
+  Enter: true,
+  Backspace: true,
+  ArrowRight: true,
+  ArrowLeft: true,
+  ArrowUp: true,
+  ArrowDown: true,
+  /**
+   * Caps lock is a strange case where it not only does not have a key press event,
+   * but it's keyup event is triggered when caps lock is toggled off
+   */
+  CapsLock: true,
+};
+
+for(let i = 1; i < 13; i++) {
+  KeysWithKeyupHiddenByCmd[`F${i}`] = true;
+}
+
+export default KeysWithKeyupHiddenByCmd;

--- a/src/helpers/resolving-handlers/keyupIsHiddenByCmd.js
+++ b/src/helpers/resolving-handlers/keyupIsHiddenByCmd.js
@@ -1,0 +1,14 @@
+import KeysWithKeyupHiddenByCmd from '../../const/KeysWithKeyupHiddenByCmd';
+import hasKey from '../../utils/object/hasKey';
+
+/**
+ * Whether the specified key, when pressed down with the cmd key, never triggers a keyup
+ * event in the browser
+ * @param {NormalizedKeyName} keyName Name of the key
+ * @returns {Boolean} Whether the key has its keyup event hidden by cmd
+ */
+function keyupIsHiddenByCmd(keyName) {
+  return keyName.length === 1 || hasKey(KeysWithKeyupHiddenByCmd, keyName);
+}
+
+export default keyupIsHiddenByCmd;

--- a/src/lib/KeyEventBitmapManager.js
+++ b/src/lib/KeyEventBitmapManager.js
@@ -21,7 +21,7 @@ class KeyEventBitmapManager {
    * @param {KeyEventBitmapIndex=} eventBitmapIndex Index of bit to set to true
    * @returns {KeyEventBitmap} New key event bitmap with bit set to true
    */
-  static newBitmap(eventBitmapIndex ) {
+  static newBitmap(eventBitmapIndex) {
     const bitmap = [ false, false, false ];
 
     if (!isUndefined(eventBitmapIndex)) {

--- a/src/lib/strategies/AbstractKeyEventStrategy.js
+++ b/src/lib/strategies/AbstractKeyEventStrategy.js
@@ -26,6 +26,7 @@ import keyIsCurrentlyTriggeringEvent from '../../helpers/parsing-key-maps/keyIsC
 import isMatchPossibleBasedOnNumberOfKeys from '../../helpers/resolving-handlers/isMatchPossibleBasedOnNumberOfKeys';
 import copyAttributes from '../../utils/object/copyAttributes';
 import hasKey from '../../utils/object/hasKey';
+import keyupIsHiddenByCmd from '../../helpers/resolving-handlers/keyupIsHiddenByCmd';
 
 const SEQUENCE_ATTRIBUTES = ['sequence', 'action'];
 const KEYMAP_ATTRIBUTES = ['name', 'description', 'group'];
@@ -769,7 +770,7 @@ class AbstractKeyEventStrategy {
     if (eventType === KeyEventBitmapIndex.keypress) {
       return !keyHasNativeKeypress || (keyHasNativeKeypress && this._keyIsCurrentlyDown('Meta'));
     } else if (eventType === KeyEventBitmapIndex.keyup) {
-      return (keyHasNativeKeypress && keyIsCurrentlyTriggeringEvent(
+      return (keyupIsHiddenByCmd(keyName) && keyIsCurrentlyTriggeringEvent(
         this._getCurrentKeyState('Meta'),
         KeyEventBitmapIndex.keyup)
       );


### PR DESCRIPTION
# Context

`react-hotkeys` simulates some key events the browser does not trigger itself, to avoid users of `react-hotkeys` from having to think about which events are natively supported or not. One of the events that `react-hotkeys` simulates is the `keyup` event in key combinations involving the `cmd` key (e.g. `cmd+a`). 

Some keys when pressed with `cmd` still trigger their own `keyup` event, but there is a list of keys that do not. Currently `react-hotkeys` re-uses the list of keys that do not have their own `keypress` event to determine whether it should also simulate the `keyup` event. This list is incorrect and results on some `keyup` events not being simulated, and `react-hotkeys` still behaving as if they are still held down (#183).


# This pull request

* Creates a separate (correct) list, to keep track of the keys that do not natively trigger a `keyup` event when pressed with `cmd` (`Meta`).

