### PR TITLE
🌟 Fix #158: Add a recordKeyCombination function to set dynamic keyboa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See the [upgrade notes](https://github.com/greena13/react-hotkeys/releases/tag/v
 - Define [global](#GlobalHotKeys-component) and [in-focus](#HotKeys-component) hot keys
 - [Display a list of available hot keys to the user](#Displaying-a-list-of-available-hot-keys)
 - [Define custom key codes](#defining-custom-key-codes) for WebOS and other environments
-- Allow users to [set their own keyboard shortcuts](#setting-dynamic-hotkeys)
+- Allow users to [set their own keyboard shortcuts](#setting-dynamic-hotkeys-at-runtime)
 - Works with React's Synthetic KeyboardEvents and event delegation and provides [predictable and expected behaviour](#Interaction-with-React) to anyone familiar with React
 - Optimized by default, but allows you to turn off different optimisation measures in a granular fashion
 - Customizable through a simple [configuration API](#Configuration)
@@ -94,7 +94,7 @@ export default MyNode;
     - [Specifying key map display data](#specifying-key-map-display-data)
     - [Deciding which key map syntax to use](#deciding-which-key-map-syntax-to-use)
     - [Defining custom key codes](#defining-custom-key-codes)
-    - [Setting dynamic hotkeys](#setting-dynamic-hotkeys)
+    - [Setting dynamic hotkeys at runtime](#setting-dynamic-hotkeys-at-runtime)
 - [Defining Handlers](#defining-handlers)
     - [DEPRECATED: Hard Sequence Handlers](#deprecated-hard-sequence-handlers)
 - [Interaction with React](#interaction-with-react)
@@ -374,9 +374,9 @@ const keyMap = {
 };
 ```
 
-#### Setting dynamic hotkeys
+#### Setting dynamic hotkeys at runtime
 
-`react-hotkeys` has basic support for setting dynamic hotkeys - i.e. letting the user set their own keyboard shortcuts. In your app, you can set up the necessary UI for [viewing the current keyboard shortcuts](#displaying-a-list-of-available-hot-keys), and opting to change them. You can then use the `recordKeyCombination` function to capture the keys the user wishes to use.
+`react-hotkeys` has basic support for setting dynamic hotkeys - i.e. letting the user set their own keyboard shortcuts at runtime. Once you have set up the necessary UI for [viewing the current keyboard shortcuts](#displaying-a-list-of-available-hot-keys) (and opting to change them), you can then use the `recordKeyCombination` function to capture the keys the user wishes to use.
 
 `recordKeyCombination` accepts a callback function that will be called on the last `keyup` of the next key combination - immediately after the user has pressed the key combination they wish to assign. The callback then unbinds itself, so you do not have to worry about tidying up after it.
 
@@ -387,7 +387,8 @@ The callback function receives a single argument with the following schema:
 ```javascript
 {
   /**
-   * Id of combination that could be used to define a keymap
+   * Combination ID that can be passed to the keyMap prop to (re)define an
+   * action's key sequence 
    */
   id: '',
   /**
@@ -395,9 +396,21 @@ The callback function receives a single argument with the following schema:
    */
   keys: { keyName: true }
 }
+
+// Example:
+
+{
+  id: 'a', 
+  keys: { a: true }
+}
 ```
+
+If you are updating hotkeys without changing focus or remounting the component that defines them, you will need to make sure you use the [`allowChanges` prop](#hotkeys-component-api) to ensure the new keymaps are honoured immediately.
  
-A basic example is:
+An example, rendering two dialogs: 
+
+* One for displaying the application's key maps using the [getApplicationKeyMap](#displaying-a-list-of-available-hot-keys) function
+* Another for telling the user when to press the keys they want to bind to an action, meanwhile listening with `recordKeyCombination()` 
 
 ```javascript
 import { recordKeyCombination } from 'react-hotkeys';
@@ -484,8 +497,6 @@ showChangeShortcutDialog(actionName) {
   });    
 }
 ```
-
-If you are updating hotkeys without changing focus or remounting the component that defines them, you will need to make sure you use the [`allowChanges` prop](#hotkeys-component-api) to ensure the new keymaps are honoured immediately.
 
 ## Defining Handlers
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -222,7 +222,7 @@ export interface KeyCombination {
 /**
  * Function to call to cancel listening to the next key combination
  */
-declare type cancelKeyCombinationListener = () => void;
+export declare type cancelKeyCombinationListener = () => void;
 
 /**
  * Adds a listener function that will be called the next time a key combination completes

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 export type MouseTrapKeySequence = string | Array<string>;
 
 export type ActionName = string;
+export type KeyName = string;
 
 export type KeyEventName = 'keyup' | 'keydown' | 'keypress';
 
@@ -202,6 +203,33 @@ export type ApplicationKeyMap = { [key in ActionName]: KeyMapDisplayOptions };
  * HotKeys and GlobalHotKeys components that are currently mounted
  */
 export declare function getApplicationKeyMap(): ApplicationKeyMap;
+
+/**
+ * Description of key combination passed to the callback registered with
+ * the recordKeyCombination function
+ */
+export interface KeyCombination {
+  /**
+   * Id of combination that could be used to define a keymap
+   */
+  id: MouseTrapKeySequence;
+  /**
+   * Dictionary of keys involved in the combination
+   */
+  keys: { [key in KeyName]: true };
+}
+
+/**
+ * Function to call to cancel listening to the next key combination
+ */
+declare type cancelKeyCombinationListener = () => void;
+
+/**
+ * Adds a listener function that will be called the next time a key combination completes
+ * Returns a function to cancel listening.
+ */
+export declare function recordKeyCombination(callbackFunction: (keyCombination: KeyCombination) => void): cancelKeyCombinationListener;
+
 
 export interface ConfigurationOptions {
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -9,4 +9,5 @@ export {default as withObserveKeys} from './withObserveKeys';
 export {default as configure} from './configure';
 
 export {default as getApplicationKeyMap} from './getApplicationKeyMap';
+export {default as recordKeyCombination} from './recordKeyCombination';
 

--- a/src/lib/KeyEventManager.js
+++ b/src/lib/KeyEventManager.js
@@ -176,6 +176,12 @@ class KeyEventManager {
   /********************************************************************************
    * Recording key combination
    ********************************************************************************/
+
+  /**
+   * Adds a listener function that will be called the next time a key combination completes
+   * @param {keyCombinationListener} callbackFunction Listener function to be called
+   * @returns {function} Function to call to cancel listening to the next key combination
+   */
   addKeyCombinationListener(callbackFunction) {
     return this._globalEventStrategy.addKeyCombinationListener(callbackFunction);
   }

--- a/src/lib/KeyEventManager.js
+++ b/src/lib/KeyEventManager.js
@@ -174,6 +174,13 @@ class KeyEventManager {
   }
 
   /********************************************************************************
+   * Recording key combination
+   ********************************************************************************/
+  addKeyCombinationListener(callbackFunction) {
+    return this._globalEventStrategy.addKeyCombinationListener(callbackFunction);
+  }
+
+  /********************************************************************************
    * Focus key events
    ********************************************************************************/
 

--- a/src/lib/strategies/AbstractKeyEventStrategy.js
+++ b/src/lib/strategies/AbstractKeyEventStrategy.js
@@ -748,6 +748,19 @@ class AbstractKeyEventStrategy {
   }
 
   /**
+   * Whether there are any keys in the current combination still being pressed
+   * @protected
+   * @return {Boolean} True if all keys in the current combination are released
+   */
+  _allKeysAreReleased() {
+    const currentCombination = this._getCurrentKeyCombination();
+
+    return Object.keys(currentCombination.keys).every((keyName) => {
+      return !this._keyIsCurrentlyDown(keyName);
+    });
+  }
+
+  /**
    * Returns a new KeyCombinationRecord without the keys that have been
    * released (had the keyup event recorded). Essentially, the keys that are
    * currently still pressed down at the time a key event is being handled.

--- a/src/lib/strategies/AbstractKeyEventStrategy.js
+++ b/src/lib/strategies/AbstractKeyEventStrategy.js
@@ -749,8 +749,8 @@ class AbstractKeyEventStrategy {
 
   /**
    * Whether there are any keys in the current combination still being pressed
-   * @protected
    * @return {Boolean} True if all keys in the current combination are released
+   * @protected
    */
   _allKeysAreReleased() {
     const currentCombination = this._getCurrentKeyCombination();

--- a/src/lib/strategies/GlobalKeyEventStrategy.js
+++ b/src/lib/strategies/GlobalKeyEventStrategy.js
@@ -243,6 +243,13 @@ class GlobalKeyEventStrategy extends AbstractKeyEventStrategy {
     }
   }
 
+  /**
+   * Whether the document listeners should be bound, to record key events. Basically a check
+   * to see if there are any global key maps, or whether the user is currently rebinding to
+   * a new key combination.
+   * @returns {boolean} True if the document listeners should be bound
+   * @private
+   */
   _listenersShouldBeBound() {
     return this.componentList.length > 0 || this.listeners.keyCombination;
   }

--- a/src/recordKeyCombination.js
+++ b/src/recordKeyCombination.js
@@ -1,0 +1,18 @@
+import KeyEventManager from './lib/KeyEventManager';
+
+/**
+ * @callback keyCombinationListener
+ */
+
+/**
+ * Adds a listener function that will be called the next time a key combination completes
+ * @param {keyCombinationListener} callbackFunction Listener function to be called
+ * @returns {function} Function to call to cancel listening to the next key combination
+ */
+function recordKeyCombination(callbackFunction) {
+  const eventManager = KeyEventManager.getInstance();
+
+  return eventManager.addKeyCombinationListener(callbackFunction);
+}
+
+export default recordKeyCombination;

--- a/test/GlobalHotKeys/ClosingHangingCombinationsInHotKeysComponents.spec.js
+++ b/test/GlobalHotKeys/ClosingHangingCombinationsInHotKeysComponents.spec.js
@@ -11,7 +11,7 @@ import KeyCode from '../support/Key';
 
 import {HotKeys, GlobalHotKeys} from '../../src';
 
-describe('ClosingHangingCombinationsInHotKeysComponents:', function () {
+describe('Closing hanging combinations in HotKeys Components:', function () {
   describe('when a HotKeys component has a handler on keydown that changes the focus to outside its descendants', function () {
     beforeEach(function () {
       this.keyMap = {

--- a/test/recordKeyCombination/addingKeyCombinationListener.spec.js
+++ b/test/recordKeyCombination/addingKeyCombinationListener.spec.js
@@ -1,0 +1,267 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {expect} from 'chai';
+import sinon from 'sinon';
+import simulant from 'simulant';
+
+import {HotKeys, GlobalHotKeys,recordKeyCombination} from '../../src/';
+import KeyCode from '../support/Key';
+import FocusableElement from '../support/FocusableElement';
+
+describe('Adding key combination listener:', () => {
+  context('when only a HotKeys component is mounted', () => {
+    context('without any keyMap or handlers', () => {
+      beforeEach(function () {
+        this.reactDiv = document.createElement('div');
+        document.body.appendChild(this.reactDiv);
+
+        this.wrapper = mount(
+          <HotKeys>
+            <div className="childElement" />
+          </HotKeys>,
+          { attachTo: this.reactDiv }
+        );
+      });
+
+      afterEach(function() {
+        document.body.removeChild(this.reactDiv);
+      });
+
+      it('calls the combination listener', function() {
+        const callback = sinon.spy();
+        recordKeyCombination(callback);
+
+        simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+        simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+        expect(callback).to.not.have.been.called;
+
+        simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+
+        expect(callback).to.have.been.calledOnce;
+
+        expect(callback).to.have.been.calledWithMatch({
+          keys: { a: true },
+          id: 'a'
+        });
+      });
+    });
+
+    context('with a keyMap', () => {
+      beforeEach(function () {
+        this.keyMap = {
+          'ACTION1': 'a'
+        };
+
+        this.handler = sinon.spy();
+
+        this.handlers = {
+          'ACTION1': this.handler,
+        };
+
+        this.reactDiv = document.createElement('div');
+        document.body.appendChild(this.reactDiv);
+
+        this.wrapper = mount(
+          <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+            <div className="childElement" />
+          </HotKeys>,
+          { attachTo: this.reactDiv }
+        );
+
+        this.firstElement = new FocusableElement(this.wrapper, '.childElement');
+        this.firstElement.focus();
+      });
+
+      afterEach(function() {
+        document.body.removeChild(this.reactDiv);
+      });
+
+      it('then calls the combination listener after any matching handlers', function() {
+        const callback = sinon.spy();
+        recordKeyCombination(callback);
+
+        this.firstElement.keyDown(KeyCode.A);
+        simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+
+        this.firstElement.keyPress(KeyCode.A);
+        simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+        this.firstElement.keyUp(KeyCode.A);
+        simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+
+        expect(this.handler).to.have.been.calledOnce;
+        expect(callback).to.have.been.calledOnce;
+
+        expect(callback).to.have.been.calledAfter(this.handler);
+      });
+    });
+  });
+
+  context('when only a GlobalHotKeys component is mounted', () => {
+    context('without any keyMap or handlers', () => {
+      beforeEach(function () {
+        this.reactDiv = document.createElement('div');
+        document.body.appendChild(this.reactDiv);
+
+        this.wrapper = mount(
+          <GlobalHotKeys>
+            <div className="childElement" />
+          </GlobalHotKeys>,
+          { attachTo: this.reactDiv }
+        );
+      });
+
+      afterEach(function() {
+        document.body.removeChild(this.reactDiv);
+      });
+
+      it('then calls the combination listener', function() {
+        const callback = sinon.spy();
+        recordKeyCombination(callback);
+
+        simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+        simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+
+        expect(callback).to.not.have.been.called;
+
+        simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+
+        expect(callback).to.have.been.calledOnce;
+
+        expect(callback).to.have.been.calledWithMatch({
+          keys: { a: true },
+          id: 'a'
+        });
+      });
+    });
+
+    context('with a keyMap', () => {
+      beforeEach(function () {
+        this.keyMap = {
+          'ACTION1': 'a'
+        };
+
+        this.handler = sinon.spy();
+
+        this.handlers = {
+          'ACTION1': this.handler,
+        };
+
+        this.reactDiv = document.createElement('div');
+        document.body.appendChild(this.reactDiv);
+
+        this.wrapper = mount(
+          <GlobalHotKeys keyMap={this.keyMap} handlers={this.handlers}>
+            <div className="childElement" />
+          </GlobalHotKeys>,
+          { attachTo: this.reactDiv }
+        );
+      });
+
+      afterEach(function() {
+        document.body.removeChild(this.reactDiv);
+      });
+
+      it('then calls the combination listener after any matching handlers', function() {
+        const callback = sinon.spy();
+        recordKeyCombination(callback);
+
+        simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+        simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+        simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+
+        expect(this.handler).to.have.been.calledOnce;
+        expect(callback).to.have.been.calledOnce;
+
+        expect(callback).to.have.been.calledAfter(this.handler);
+      });
+    });
+  });
+
+  context('when the cancel function is called', () => {
+    beforeEach(function () {
+      this.reactDiv = document.createElement('div');
+      document.body.appendChild(this.reactDiv);
+
+      this.wrapper = mount(
+        <HotKeys>
+          <div className="childElement" />
+        </HotKeys>,
+        { attachTo: this.reactDiv }
+      );
+
+      this.callback = sinon.spy();
+      const cancel = recordKeyCombination(this.callback);
+
+      cancel();
+    });
+
+    afterEach(function() {
+      document.body.removeChild(this.reactDiv);
+    });
+
+    it('then doesn\'t call the key combination listener', function() {
+      simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+      simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+      simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+
+      expect(this.callback).to.not.have.been.called;
+    });
+  });
+
+  context('when the listener has already been called', () => {
+    beforeEach(function () {
+      this.reactDiv = document.createElement('div');
+      document.body.appendChild(this.reactDiv);
+
+      this.wrapper = mount(
+        <HotKeys>
+          <div className="childElement" />
+        </HotKeys>,
+        { attachTo: this.reactDiv }
+      );
+
+      this.callback = sinon.spy();
+      recordKeyCombination(this.callback);
+
+      simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+      simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.A });
+      simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.A });
+
+      expect(this.callback).to.have.been.called;
+    });
+
+    afterEach(function() {
+      document.body.removeChild(this.reactDiv);
+    });
+
+    context('and it\'s not rebound', () => {
+      it('then doesn\'t call the key combination listener again', function() {
+        simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+        simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+        simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.B });
+
+        expect(this.callback).to.have.been.calledOnce;
+      });
+    });
+
+    context('and it\'s rebound', () => {
+      beforeEach(function () {
+        this.newCallback = sinon.spy();
+        recordKeyCombination(this.newCallback);
+      });
+
+      it('then calls the new key combination listener', function() {
+        simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+        simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+        simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.B });
+
+        expect(this.newCallback).to.have.been.calledWithMatch({
+          keys: { b: true },
+          id: 'b'
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Context

Some users of `react-hotkeys` want the ability to allow the users of their applications to set their keyboard shortcuts dynamically. This has been request in #158.

# This pull request

* Adds a `recordKeyCombination` function, that allows binding to the next key combination, which can then be used to dynamically set keyboard shortcuts. An example usage:

```javascript
import { recordKeyCombination } from 'react-hotkeys';

renderDialog(){
  if (this.state.showShortcutsDialog) {
    const keyMap = getApplicationKeyMap();

    return (
      <div style={styles.DIALOG}>
        <h2>
          Keyboard shortcuts
        </h2>

        <table>
          <tbody>
          { 
            Object.keys(keyMap).reduce((memo, actionName) => {
              const { sequences, name } = keyMap[actionName];
              
              memo.push(
                <tr key={name || actionName}>
                  <td style={styles.KEYMAP_TABLE_CELL}>
                    { name }
                  </td>
                  <td style={styles.KEYMAP_TABLE_CELL}>
                    { sequences.map(({sequence}) => <span key={sequence}>{sequence}</span>) }
                  </td>
                  <td style={styles.KEYMAP_TABLE_CELL}>
                    <button onClick={ () => this.showChangeShortcutDialog(actionName) }>
                      Change
                    </button>
                  </td>
                </tr>
              )
            }
          }
          </tbody>
        </table>
      </div>
    );
  } else if (this.state.changingActionShortcut) {
    const { cancel } = this.state.changingActionShortcut;
    
    const keyMap = getApplicationKeyMap();
    const { name } = keyMap[this.state.changingActionShortcut];
    
    return (
      <div style={styles.DIALOG}>
        Press the keys you would like to bind to #{name}.
        
        <button onClick={cancel}>
          Cancel
        </button>
      </div>       
    );
  }
}

showChangeShortcutDialog(actionName) {
  const cancelListening = recordKeyCombination(({id}) => {
      this.setState({
        showShortcutsDialog: true,
        changingActionShortcut: null,
        keyMap: {
          ...this.state.keyMap,
          [actionName]: id      
        }
      }); 
  });
  
  this.setState({
    showShortcutsDialog: false,
    changingActionShortcut: {
      cancel: () => {
        cancelListening();
        
        this.setState({
          showShortcutsDialog: true,
          changingActionShortcut: null
        }); 
      }
    }
  });    
}
```
* Add new TypeScript definitions  for `recordKeyCombination`
* Add tests covering basic usage of `recordKeyCombination`
* Update Readme to mention new functionality

# Limitations

This is a basic first pass at the feature. It works, but skims over some of complexity that may be involved. It doesn't, for example, warn of conflicts with existing shortcuts. And it pre-supposes that the user has set up their application in a way that's somewhat antithetical to the ethos of `react-hotkeys`: they have centralised their keyboard definitions in such a manner that lets them be modified at runtime (not-so-easy if you have defined them at the component level, across many different levels). 

It is up to the user to prioritise and architect a suitable solution that will accomodate this in their app.