### PR TITLE
🐛 Fix #201: Always allow submatches for combinations involving command

### DIFF
--- a/src/helpers/resolving-handlers/isMatchPossibleBasedOnNumberOfKeys.js
+++ b/src/helpers/resolving-handlers/isMatchPossibleBasedOnNumberOfKeys.js
@@ -8,15 +8,17 @@ import Configuration from '../../lib/Configuration';
  *        in the key event.
  * @param {ActionConfiguration} combinationMatcher Matcher to compare to the
  *        key state
+ * @param {boolean} keyupIsHiddenByCmd Whether current combination involves the
+ *        cmd key and keys for which it hides their keyup event
  * @returns {boolean} True if the key state has the right amount of keys for a
  *        match with combinationMatcher to be possible
  * @private
  */
-function isMatchPossibleBasedOnNumberOfKeys(keyState, combinationMatcher) {
+function isMatchPossibleBasedOnNumberOfKeys(keyState, combinationMatcher, keyupIsHiddenByCmd) {
   const keyStateKeysNo = Object.keys(keyState.keys).length;
   const combinationKeysNo = Object.keys(combinationMatcher.keyDictionary).length;
 
-  if (Configuration.option('allowCombinationSubmatches')) {
+  if (keyupIsHiddenByCmd || Configuration.option('allowCombinationSubmatches')) {
     return keyStateKeysNo >= combinationKeysNo;
   } else {
     /**

--- a/src/lib/Configuration.js
+++ b/src/lib/Configuration.js
@@ -112,6 +112,12 @@ const _defaultConfiguration = {
    * Whether to allow combination submatches - e.g. if there is an action bound to
    * cmd, pressing shift+cmd will *not* trigger that action when
    * allowCombinationSubmatches is false.
+   *
+   * @note This option is ignored for combinations involving command (Meta) and
+   *      submatches are <i>always</i> allowed because Meta hides keyup events
+   *      of other keys, so until Command is released, it's impossible to know
+   *      if one of the keys that has also been pressed has been released.
+   *      @see https://github.com/greena13/react-hotkeys/pull/207
    * @type {Boolean}
    */
   allowCombinationSubmatches: false,

--- a/src/lib/strategies/AbstractKeyEventStrategy.js
+++ b/src/lib/strategies/AbstractKeyEventStrategy.js
@@ -789,14 +789,13 @@ class AbstractKeyEventStrategy {
       return !keyHasNativeKeypress || (keyHasNativeKeypress && this._keyIsCurrentlyDown('Meta'));
     } else if (eventType === KeyEventRecordIndex.keyup) {
       return (keyupIsHiddenByCmd(keyName) && keyIsCurrentlyTriggeringEvent(
-        this._getCurrentKeyState('Meta'),
-        KeyEventRecordIndex.keyup)
+          this._getCurrentKeyState('Meta'),
+          KeyEventRecordIndex.keyup)
       );
     }
 
     return false
   }
-
   _cloneAndMergeEvent(event, extra) {
     const eventAttributes = Object.keys(ModifierFlagsDictionary).reduce((memo, eventAttribute) => {
       memo[eventAttribute] = event[eventAttribute];
@@ -1069,7 +1068,14 @@ class AbstractKeyEventStrategy {
               const combinationId = combinationOrder[combinationIndex];
               const combinationMatcher = matchingSequence.combinations[combinationId];
 
-              if (isMatchPossibleBasedOnNumberOfKeys(currentKeyState, combinationMatcher)) {
+              const cmdKeyIsPressed =
+                this._getCurrentKeyState('Meta') && !keyIsCurrentlyTriggeringEvent(this._getCurrentKeyState('Meta'), KeyEventRecordIndex.keyup);
+
+              const keyupIsHidden = cmdKeyIsPressed && Object.keys(combinationMatcher.keyDictionary).some((keyName) => {
+                return keyupIsHiddenByCmd(keyName);
+              });
+
+              if (isMatchPossibleBasedOnNumberOfKeys(currentKeyState, combinationMatcher, keyupIsHidden)) {
                 if (this._combinationMatchesKeys(normalizedKeyName, currentKeyState, combinationMatcher, eventRecordIndex)) {
 
                   if (Configuration.option('allowCombinationSubmatches')) {

--- a/test/GlobalHotKeys/HoldingDownKeySharedByActions.spec.js
+++ b/test/GlobalHotKeys/HoldingDownKeySharedByActions.spec.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {expect} from 'chai';
+import sinon from 'sinon';
+import simulant from 'simulant';
+
+import KeyCode from '../support/Key';
+import { configure, GlobalHotKeys } from '../../src';
+
+describe('Holding down key shared by actions:', function () {
+  after(function() {
+    configure({allowCombinationSubmatches: false });
+  });
+
+  [true, false].forEach((allowCombinationSubmatches) => {
+    describe(`when allowCombinationSubmatches is ${allowCombinationSubmatches}`, () => {
+      before(function(){
+        configure({allowCombinationSubmatches: allowCombinationSubmatches });
+      });
+
+      describe('and there are two actions with combinations that involve cmd (cmd+a and cmd+b) (https://github.com/greena13/react-hotkeys/issues/201)', function () {
+        beforeEach(function () {
+          this.keyMap = {
+            'ACTION1': 'cmd+a',
+            'ACTION2': 'cmd+b',
+          };
+
+          this.handler1 = sinon.spy();
+          this.handler2 = sinon.spy();
+
+          const handlers = {
+            'ACTION1': this.handler1,
+            'ACTION2': this.handler2
+          };
+
+          this.reactDiv = document.createElement('div');
+          document.body.appendChild(this.reactDiv);
+
+          this.wrapper = mount(
+            <GlobalHotKeys keyMap={ this.keyMap } handlers={ handlers }>
+              <div className="childElement" />
+            </GlobalHotKeys>,
+            { attachTo: this.reactDiv }
+          );
+        });
+
+        afterEach(function() {
+          document.body.removeChild(this.reactDiv);
+        });
+
+        describe('and cmd and \'a\' are pressed, and \'a\' is released and \'b\' is pressed instead', function () {
+          it('then both actions are triggered', function() {
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.COMMAND });
+
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.A });
+
+            expect(this.handler1).to.have.been.calledOnce;
+
+            simulant.fire(this.reactDiv, 'keydown', { key: KeyCode.B });
+            simulant.fire(this.reactDiv, 'keypress', { key: KeyCode.B });
+
+            simulant.fire(this.reactDiv, 'keyup', { key: KeyCode.COMMAND });
+
+            expect(this.handler2).to.have.been.calledOnce;
+          });
+        });
+      })
+    });
+  });
+});


### PR DESCRIPTION
# Context

When the `Cmd` (`Meta`) key is pressed down with other keys, it hides their `keyup` events, and only the `Meta` key `keyup` event is triggered. `react-hotkeys` accounts for this and simulates the `keyup` events for all the keys `Meta` was pressed down with, when the its `keyup` event is detected.

However, if you hold down `Meta` with another key, release the other key and press a third key while `Meta` is still down, `react-hotkeys` does not know the first key has been released until you also release `Meta`. So for example, if you press `Meta` down, then `a`, then release `a` and press `b` - `react-hotkeys` thinks you're still holding `Meta+a+b` until you release `Meta`. This is undesirable, but (so far as I can come up with) unavoidable, and generally does not cause problems. 

When it does cause a problem is if you have actions for both `Meta+a` and `Meta+b`: the second action is never triggered. This used to work through submatching: `Meta+a+b` would still match an action bound to `Meta+b`. However, [v2.0.0-pre7](https://github.com/greena13/react-hotkeys/releases/tag/v2.0.0-pre7) introduced a new configuration option `allowCombinationSubmatches` (which is `false` by default) to address the multiple issues submatches were causing (#161, #181, #175), that disables this. And so we arrive at #201.

# This pull request

* Ignores the `allowCombinationSubmatches` when Command is currently pressed

