### PR TITLE
🐛 fix typo in FocusableElement

### DIFF
--- a/test/support/FocusableElement.js
+++ b/test/support/FocusableElement.js
@@ -57,6 +57,6 @@ export default class FocusableElement {
   }
 
   getInstance() {
-    lazyLoadAttribute(this, 'instance', () => this.element.getDOOMNode());
+    lazyLoadAttribute(this, 'instance', () => this.element.getDOMNode());
   }
 };


### PR DESCRIPTION
`getInstance` isn't currently used, but clearly this will need fixing if it is going to be!