### PR TITLE
🐛 Fix incorrect keyboard event type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,7 +39,7 @@ export interface GlobalHotKeysProps extends React.HTMLAttributes<HotKeys> {
   /**
    * A map from action names to event handler functions
    */
-  handlers?: { [key: string]: (keyEvent?: KeyboardEvent) => void };
+  handlers?: { [key: string]: (keyEvent?: React.KeyboardEvent) => void };
 
   /**
    * Whether the keyMap or handlers are permitted to change after the
@@ -271,7 +271,7 @@ export interface ConfigurationOptions {
    * Hotkeys. By default, keyboard events originating elements with a tag name in
    * ignoreTags, or a isContentEditable property of true, are ignored.
    */
-  ignoreEventsCondition?: (keyEvent: KeyboardEvent) => boolean,
+  ignoreEventsCondition?: (keyEvent: React.KeyboardEvent) => boolean,
 
   /**
    * Whether to ignore repeated keyboard events when a key is being held down


### PR DESCRIPTION
When attempting to use [`lodash.throttle()`](https://lodash.com/docs/4.17.15#throttle) on a handler I noticed the event object is typed as the native `KeyboardEvent` but the object given to the handler is a `React.KeyboardEvent`.

The typing should be `React.KeyboardEvent` so that `event.persist()` is visible to the TypeScript compiler.

Calling `event.persist()` is necessary when using `lodash.throttle()` because otherwise the event object will be cleared and returned to the synthetic event pool by the time the throttle function is called.

This might break dependent TypeScript code that has the native keyboard event in its handler signatures?

Let me know if there is something I'm overlooking.