### PR TITLE
Fix npm deprecation warning and allow install from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "lint": "eslint .",
     "tests": "mocha",
     "watch-tests": "mocha --watch",
-    "prepublish": "npm run build-cjs && npm run build-es && npm run build-umd",
+    "prepare": "npm run build-cjs && npm run build-es && npm run build-umd",
     "build-cjs": "rm -rf cjs && npm run build-development && npm run build-production",
     "build-es": "rm -rf es && npm run build-es-development && npm run build-es-production",
     "build-umd": "rm -rf umd && npm run build-umd-development && npm run build-umd-production",


### PR DESCRIPTION
npm has a deprecation warning for prepublish scripts now:

```
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```

Instead, we're supposed to use `prepare` scripts to build the package. This has the added advantage of being run after installing from a tarball, so if someone wants to install a prerelease version of react-hotkeys from Github say, they can just point at the github tarball and npm will run the `prepare` script and create the actual JS files needed to import, instead of it failing to import because they aren't in git.