### PR TITLE
Fix a syntax error in the types definition file on TypeScript 3.9.3

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ export type KeyMap = { [key in ActionName]: KeySequence };
  * selectively triggers actions (that may be handled by handler functions) when a
  * sequence of events matches a list of pre-defined sequences or combinations
  */
-export type HotKeysEnabled = React.ComponentType<HotKeysProps> { }
+export type HotKeysEnabled = React.ComponentType<HotKeysProps>;
 
 export interface GlobalHotKeysProps extends React.HTMLAttributes<HotKeys> {
   /**


### PR DESCRIPTION
This file was throwing a TypeScript syntax error when being required:

```
  ../../node_modules/@gadgetinc/react-hotkeys/index.d.ts(31,64): error TS1005: ';' expected.
```

This fixes it, types aren't like interfaces and can't have empty brackets.